### PR TITLE
feat: Config options & freebox nas service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,14 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
+# Secrets - NEVER commit these
+appsettings.Development.json
+appsettings.Production.json
+appsettings.*.json
+!appsettings.json
+secrets.json
+**/secrets/**
+
 # Visual Studio
 .vs/
 *.rsuser

--- a/MediaHandler.API/MediaHandler.API.csproj
+++ b/MediaHandler.API/MediaHandler.API.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>74395325-16b4-4b59-8a0c-78c9b9afddc1</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MediaHandler.API/appsettings.json
+++ b/MediaHandler.API/appsettings.json
@@ -13,13 +13,19 @@
   "Okta": {
     "Domain": "",
     "ClientId": "",
+    "ClientSecret": "",
     "Audience": "api://mediahandler"
   },
   "Tmdb": {
     "BaseUrl": "https://api.themoviedb.org/3",
-    "ImageBaseUrl": "https://image.tmdb.org/t/p"
+    "ImageBaseUrl": "https://image.tmdb.org/t/p",
+    "ApiKey": ""
   },
   "Nas": {
-    "BasePath": ""
+    "BasePaths": [],
+    "FreeboxUrl": "http://mafreebox.freebox.fr",
+    "AppId": "mediahandler",
+    "AppToken": "",
+    "ApiVersion": "v8"
   }
 }

--- a/MediaHandler.Infrastructure/DependencyInjection.cs
+++ b/MediaHandler.Infrastructure/DependencyInjection.cs
@@ -1,9 +1,12 @@
 using MediaHandler.Domain.Interfaces;
 using MediaHandler.Infrastructure.Identity;
+using MediaHandler.Infrastructure.Nas;
+using MediaHandler.Infrastructure.Options;
 using MediaHandler.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace MediaHandler.Infrastructure;
 
@@ -16,7 +19,31 @@ public static class DependencyInjection
                 configuration.GetConnectionString("DefaultConnection"),
                 b => b.MigrationsAssembly(typeof(MediaHandlerDbContext).Assembly.FullName)));
 
+        services.AddOptions<OktaOptions>()
+            .Bind(configuration.GetSection(OktaOptions.Section))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<TmdbOptions>()
+            .Bind(configuration.GetSection(TmdbOptions.Section))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<NasOptions>()
+            .Bind(configuration.GetSection(NasOptions.Section))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
         services.AddScoped<ICurrentUserService, CurrentUserService>();
+
+        services.AddHttpClient("Freebox")
+            .ConfigureHttpClient((sp, client) =>
+            {
+                var options = sp.GetRequiredService<IOptions<NasOptions>>().Value;
+                client.BaseAddress = new Uri(options.FreeboxUrl);
+            });
+
+        services.AddSingleton<INasService, FreeboxNasService>();
 
         return services;
     }

--- a/MediaHandler.Infrastructure/Nas/FreeboxNasService.cs
+++ b/MediaHandler.Infrastructure/Nas/FreeboxNasService.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using MediaHandler.Domain.Interfaces;
+using MediaHandler.Infrastructure.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MediaHandler.Infrastructure.Nas;
+
+public sealed class FreeboxNasService : INasService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly NasOptions _options;
+    private readonly ILogger<FreeboxNasService> _logger;
+    private readonly SemaphoreSlim _sessionLock = new(1, 1);
+    private string? _sessionToken;
+
+    public FreeboxNasService(
+        IHttpClientFactory httpClientFactory,
+        IOptions<NasOptions> options,
+        ILogger<FreeboxNasService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<NasFileInfo>> ScanDirectoryAsync(string basePath, CancellationToken cancellationToken = default)
+    {
+        var response = await GetFreeboxAsync<FreeboxResponse<List<FreeboxFileEntry>>>(
+            $"/api/{_options.ApiVersion}/fs/ls/{EncodePath(basePath)}", cancellationToken);
+
+        if (response?.Success != true || response.Result is null)
+        {
+            _logger.LogWarning("Failed to scan directory {Path}: {Message}", basePath, response?.Msg);
+            return [];
+        }
+
+        return response.Result.Where(e => e.Type == "file").Select(MapToNasFileInfo);
+    }
+
+    public async Task<bool> FileExistsAsync(string filePath, CancellationToken cancellationToken = default) =>
+        await GetFileInfoAsync(filePath, cancellationToken) is not null;
+
+    public async Task<NasFileInfo?> GetFileInfoAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var response = await GetFreeboxAsync<FreeboxResponse<FreeboxFileEntry>>(
+            $"/api/{_options.ApiVersion}/fs/info/{EncodePath(filePath)}", cancellationToken);
+
+        return response?.Success == true && response.Result is not null
+            ? MapToNasFileInfo(response.Result)
+            : null;
+    }
+
+    private async Task<T?> GetFreeboxAsync<T>(string path, CancellationToken cancellationToken, bool isRetry = false)
+    {
+        var token = await EnsureSessionTokenAsync(cancellationToken);
+        var client = _httpClientFactory.CreateClient("Freebox");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("X-Fbx-App-Auth", token);
+
+        var httpResponse = await client.SendAsync(request, cancellationToken);
+
+        if (httpResponse.StatusCode == HttpStatusCode.Forbidden && !isRetry)
+        {
+            _logger.LogInformation("Freebox session expired, re-authenticating.");
+            InvalidateSession();
+            return await GetFreeboxAsync<T>(path, cancellationToken, isRetry: true);
+        }
+
+        httpResponse.EnsureSuccessStatusCode();
+        return await httpResponse.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
+    }
+
+    private async Task<string> EnsureSessionTokenAsync(CancellationToken cancellationToken)
+    {
+        if (_sessionToken is not null)
+            return _sessionToken;
+
+        await _sessionLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_sessionToken is not null)
+                return _sessionToken;
+
+            var client = _httpClientFactory.CreateClient("Freebox");
+
+            var challengeResponse = await client.GetFromJsonAsync<FreeboxResponse<FreeboxChallenge>>(
+                $"/api/{_options.ApiVersion}/login/", cancellationToken);
+
+            if (challengeResponse?.Success != true || challengeResponse.Result is null)
+                throw new InvalidOperationException("Failed to retrieve Freebox login challenge.");
+
+            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(_options.AppToken));
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(challengeResponse.Result.Challenge));
+            var password = Convert.ToHexString(hash).ToLower();
+
+            var sessionResponse = await client.PostAsJsonAsync(
+                $"/api/{_options.ApiVersion}/login/session/",
+                new FreeboxSessionRequest(_options.AppId, password),
+                cancellationToken);
+
+            var session = await sessionResponse.Content
+                .ReadFromJsonAsync<FreeboxResponse<FreeboxSessionResult>>(cancellationToken: cancellationToken);
+
+            if (session?.Success != true || session.Result?.SessionToken is null)
+                throw new InvalidOperationException("Failed to open Freebox session.");
+
+            _sessionToken = session.Result.SessionToken;
+            _logger.LogInformation("Freebox session established successfully.");
+            return _sessionToken;
+        }
+        finally
+        {
+            _sessionLock.Release();
+        }
+    }
+
+    private void InvalidateSession() => _sessionToken = null;
+
+    private static string EncodePath(string path) =>
+        WebUtility.UrlEncode(Convert.ToBase64String(Encoding.UTF8.GetBytes(path)));
+
+    private static NasFileInfo MapToNasFileInfo(FreeboxFileEntry entry)
+    {
+        var modified = DateTimeOffset.FromUnixTimeSeconds(entry.Modification).UtcDateTime;
+        var extension = Path.GetExtension(entry.Name).TrimStart('.').ToUpperInvariant();
+
+        return new NasFileInfo(
+            FilePath: entry.Path,
+            FileName: entry.Name,
+            SizeBytes: entry.Size ?? 0,
+            Format: string.IsNullOrEmpty(extension) ? null : extension,
+            CreatedAt: modified,
+            ModifiedAt: modified);
+    }
+
+    private record FreeboxResponse<T>(
+        [property: JsonPropertyName("success")] bool Success,
+        [property: JsonPropertyName("msg")] string? Msg,
+        [property: JsonPropertyName("error_code")] string? ErrorCode,
+        [property: JsonPropertyName("result")] T? Result);
+
+    private record FreeboxChallenge(
+        [property: JsonPropertyName("challenge")] string Challenge,
+        [property: JsonPropertyName("logged_in")] bool LoggedIn);
+
+    private record FreeboxSessionRequest(
+        [property: JsonPropertyName("app_id")] string AppId,
+        [property: JsonPropertyName("password")] string Password);
+
+    private record FreeboxSessionResult(
+        [property: JsonPropertyName("session_token")] string? SessionToken);
+
+    private record FreeboxFileEntry(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("path")] string Path,
+        [property: JsonPropertyName("size")] long? Size,
+        [property: JsonPropertyName("mimetype")] string? Mimetype,
+        [property: JsonPropertyName("modification")] long Modification);
+}

--- a/MediaHandler.Infrastructure/Options/NasOptions.cs
+++ b/MediaHandler.Infrastructure/Options/NasOptions.cs
@@ -1,0 +1,12 @@
+namespace MediaHandler.Infrastructure.Options;
+
+public class NasOptions
+{
+    public const string Section = "Nas";
+
+    public List<string> BasePaths { get; set; } = [];
+    public string FreeboxUrl { get; set; } = "http://mafreebox.freebox.fr";
+    public required string AppId { get; set; }
+    public required string AppToken { get; set; }
+    public string ApiVersion { get; set; } = "v8";
+}

--- a/MediaHandler.Infrastructure/Options/OktaOptions.cs
+++ b/MediaHandler.Infrastructure/Options/OktaOptions.cs
@@ -1,0 +1,11 @@
+namespace MediaHandler.Infrastructure.Options;
+
+public class OktaOptions
+{
+    public const string Section = "Okta";
+
+    public required string Domain { get; set; }
+    public required string ClientId { get; set; }
+    public required string ClientSecret { get; set; }
+    public string Audience { get; set; } = "api://mediahandler";
+}

--- a/MediaHandler.Infrastructure/Options/TmdbOptions.cs
+++ b/MediaHandler.Infrastructure/Options/TmdbOptions.cs
@@ -1,0 +1,10 @@
+namespace MediaHandler.Infrastructure.Options;
+
+public class TmdbOptions
+{
+    public const string Section = "Tmdb";
+
+    public string BaseUrl { get; set; } = "https://api.themoviedb.org/3";
+    public string ImageBaseUrl { get; set; } = "https://image.tmdb.org/t/p";
+    public required string ApiKey { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,214 @@
 # MediaHandler API
 
-A personal media management API for organizing, tracking, and discovering TV shows and films stored on a NAS.
+A personal media management API for organizing, tracking, and discovering TV shows and films stored on a Freebox NAS.
+
+## Architecture
+
+Clean Architecture with .NET 10:
+- **Domain Layer**: Entities, enums, interfaces, exceptions (no dependencies)
+- **Application Layer**: CQRS with MediatR, business logic, DTOs
+- **Infrastructure Layer**: EF Core, external services (TMDB, Freebox NAS, Okta)
+- **API Layer**: ASP.NET Core Web API controllers
+
+## Technology Stack
+
+- **.NET 10** - Latest LTS runtime
+- **ASP.NET Core** - Web API framework
+- **Entity Framework Core 9** - ORM with SQL Server
+- **MediatR** - CQRS pattern implementation
+- **FluentValidation** - Request validation
+- **Okta OAuth 2.0** - Authentication
+- **TMDB API** - Media metadata
+- **Freebox API** - NAS file system access via local Freebox router
+
+## Implementation Progress
+
+### ✅ Phase 1 — Setup
+- [x] Solution structure: Clean Architecture with 4 projects (`Domain`, `Application`, `Infrastructure`, `API`)
+- [x] Project references enforcing layer dependency rules
+- [x] `.gitignore` configured to exclude secrets and build artifacts
+- [x] `appsettings.json` with safe defaults only (no secrets committed)
+- [x] User Secrets initialized for development
+
+### ✅ Phase 2 — Domain Layer
+- [x] `BaseEntity` with audit fields (`CreatedAt`, `UpdatedAt`, `CreatedBy`, `UpdatedBy`)
+- [x] Enums: `MediaType` (Film/TvShow), `UserRole` (User/Admin)
+- [x] Entities: `User`, `Media`, `MediaFile`, `UserMedia`, `WishlistItem`, `TvSeason`, `TvEpisode`, `UserEpisode`
+- [x] Domain exceptions: `NotFoundException`, `ValidationException`
+- [x] Interfaces: `ITmdbService`, `INasService`, `ICurrentUserService`
+
+### ✅ Phase 3 — Application Layer
+- [x] `Result<T>` / `Result` pattern (no exceptions for business errors)
+- [x] `ApiResponse<T>` envelope with `ApiResponseMeta` and `ApiError`
+- [x] `PagedResult<T>` for paginated responses
+- [x] MediatR and FluentValidation registered via `DependencyInjection`
+
+### ✅ Phase 4 — Infrastructure Layer
+- [x] `MediaHandlerDbContext` with all `DbSet<T>` properties
+- [x] Fluent API entity configurations for all 8 entities (unique indexes, constraints, relations)
+- [x] EF Core migration: `InitialCreate`
+- [x] `CurrentUserService` resolving user identity from Okta JWT claims
+- [x] Strongly-typed options: `OktaOptions`, `TmdbOptions`, `NasOptions`
+- [x] **`FreeboxNasService`**: Full Freebox API integration
+  - HMAC-SHA1 session authentication against local Freebox router
+  - Automatic session token renewal on 403 expiry
+  - Directory scanning via `/api/v8/fs/ls/`
+  - File info retrieval via `/api/v8/fs/info/`
+  - Base64 + URL-encoded path encoding
+
+### 🔄 Phase 5 — API Layer (In Progress)
+- [x] `HealthController` — `GET /api/v1/health`
+- [x] Swagger / OpenAPI configured
+- [x] CORS configured
+- [ ] Okta JWT authentication middleware
+- [ ] Global exception handler middleware
+- [ ] Rate limiting
+
+### 📋 Phase 6 — Features (Planned)
+- [ ] `AuthController` — user profile & preferences
+- [ ] `MediaController` — CRUD, search, filter, paginate
+- [ ] `WatchStatusController` — mark watched/unwatched
+- [ ] `TmdbController` — search & import from TMDB
+- [ ] `FilesController` — NAS scan & folder access
+- [ ] `WishlistController` — manage desired media
+- [ ] `EpisodesController` — TV show episode tracking
+- [ ] `AdminController` — user management, system config
+
+---
+
+## Project Structure
+
+```
+MediaHandler.API/
+├── MediaHandler.Domain/
+│   ├── Common/                  BaseEntity
+│   ├── Entities/                User, Media, MediaFile, UserMedia,
+│   │                            WishlistItem, TvSeason, TvEpisode, UserEpisode
+│   ├── Enums/                   MediaType, UserRole
+│   ├── Exceptions/              NotFoundException, ValidationException
+│   └── Interfaces/              ITmdbService, INasService, ICurrentUserService
+│
+├── MediaHandler.Application/
+│   ├── Common/
+│   │   └── Models/              Result<T>, ApiResponse<T>, PagedResult<T>
+│   └── DependencyInjection.cs
+│
+├── MediaHandler.Infrastructure/
+│   ├── Identity/                CurrentUserService
+│   ├── Nas/                     FreeboxNasService
+│   ├── Options/                 OktaOptions, TmdbOptions, NasOptions
+│   ├── Persistence/
+│   │   └── Configurations/      One IEntityTypeConfiguration<T> per entity
+│   ├── MediaHandlerDbContext.cs
+│   └── DependencyInjection.cs
+│
+└── MediaHandler.API/
+    ├── Controllers/             HealthController
+    ├── appsettings.json         Safe defaults only — no secrets
+    └── Program.cs
+```
+
+---
+
+## Configuration
+
+`appsettings.json` holds only safe, non-secret values. All secrets are stored outside source control via **User Secrets** (dev) or **Environment Variables** (production).
+
+### User Secrets — Development Setup
+
+```bash
+# Okta
+dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.okta.com" --project MediaHandler.API
+dotnet user-secrets set "Okta:ClientId"      "your-client-id"             --project MediaHandler.API
+dotnet user-secrets set "Okta:ClientSecret"  "your-client-secret"         --project MediaHandler.API
+
+# TMDB
+dotnet user-secrets set "Tmdb:ApiKey"        "your-tmdb-api-key"          --project MediaHandler.API
+
+# Freebox NAS
+dotnet user-secrets set "Nas:AppId"          "mediahandler"               --project MediaHandler.API
+dotnet user-secrets set "Nas:AppToken"       "your-freebox-app-token"     --project MediaHandler.API
+dotnet user-secrets set "Nas:BasePaths:0"    "/Disk/Media/Films"          --project MediaHandler.API
+dotnet user-secrets set "Nas:BasePaths:1"    "/Disk/Media/Series"         --project MediaHandler.API
+```
+
+### Environment Variables — Production
+
+```sh
+OKTA__DOMAIN=https://dev-xxxxx.okta.com
+OKTA__CLIENTSECRET=your-secret
+TMDB__APIKEY=your-key
+NAS__APPID=mediahandler
+NAS__APPTOKEN=your-freebox-app-token
+NAS__BASEPATHS__0=/Disk/Media/Films
+NAS__BASEPATHS__1=/Disk/Media/Series
+```
+
+### Freebox App Token
+
+The `AppToken` is a one-time token granted by the Freebox OS UI. To obtain it:
+1. Make a POST to `http://mafreebox.freebox.fr/api/v8/login/authorize/` with your app info
+2. The user must physically press the `✓` button on the Freebox front panel
+3. Poll the authorization endpoint until `status` is `granted`
+4. Copy the returned `app_token` into User Secrets
+
+---
+
+## Getting Started
+
+### Prerequisites
+- .NET 10 SDK
+- SQL Server / SQL Server LocalDB
+- Okta Developer account
+- TMDB API key
+- Freebox router accessible at `http://mafreebox.freebox.fr`
+
+### Build & Run
+
+```bash
+dotnet restore
+dotnet build
+dotnet run --project MediaHandler.API
+```
+
+### Database
+
+```bash
+# Apply migration
+dotnet ef database update --project MediaHandler.Infrastructure --startup-project MediaHandler.API
+```
+
+---
+
+## API Endpoints
+
+| Status | Method | Route | Description |
+|--------|--------|-------|-------------|
+| ✅ | `GET` | `/api/v1/health` | Health check |
+| 📋 | `GET` | `/api/v1/auth/me` | Current user profile |
+| 📋 | `GET` | `/api/v1/media` | List media (paginated) |
+| 📋 | `POST` | `/api/v1/media` | Add media to collection |
+| 📋 | `GET` | `/api/v1/tmdb/search` | Search TMDB |
+| 📋 | `POST` | `/api/v1/tmdb/import/{tmdbId}` | Import media from TMDB |
+| 📋 | `PUT` | `/api/v1/media/{id}/watched` | Set watch status |
+| 📋 | `GET` | `/api/v1/wishlist` | User wishlist |
+| 📋 | `GET` | `/api/v1/files/scan` | Trigger NAS scan |
+| 📋 | `GET` | `/api/v1/admin/users` | Admin: list users |
+
+---
+
+## Development Guidelines
+
+- File-scoped namespaces, primary constructors, `record` types for DTOs
+- `#nullable enable` throughout
+- EF Core: Fluent API only, one `IEntityTypeConfiguration<T>` per entity
+- CQRS: `Result<T>` returns, one handler per file, validators in separate files
+- No secrets in source code — User Secrets for dev, env vars for production
+
+## License
+
+Private project for personal use.
+
 
 ## Architecture
 


### PR DESCRIPTION
This pull request introduces the full Freebox NAS integration into the infrastructure layer, adds strongly-typed configuration options for Okta, TMDB, and NAS, and significantly improves project documentation. It includes a new `FreeboxNasService` for accessing the Freebox NAS, updates configuration files and dependency injection, and expands the `README.md` with detailed architecture, setup, and configuration instructions.

**Infrastructure: Freebox NAS Integration**
- Added `FreeboxNasService` implementing `INasService`, providing directory scanning, file info retrieval, secure HMAC-SHA1 session authentication, and automatic session renewal with the Freebox API.
- Registered `FreeboxNasService` and a named `HttpClient` for Freebox in dependency injection, binding and validating new `NasOptions` from configuration.

**Configuration & Options**
- Introduced strongly-typed options classes: `NasOptions`, `OktaOptions`, and `TmdbOptions`, each with required fields and default values, and bound them to configuration sections. [[1]](diffhunk://#diff-984cd7ef53af1eef26095356c6baf07fffdfa34644db5a8d462ee2dbf2507a2dR1-R12) [[2]](diffhunk://#diff-4739631358622dad64aab823a0b72822fe37677963a78f50309f154dd0b982aaR1-R11) [[3]](diffhunk://#diff-fd532897411802b1f8a26febac5c7fdda27fe958b06c40ae8ff7153b8a22d72eR1-R10)
- Updated `appsettings.json` to include new fields for Okta (`ClientSecret`), TMDB (`ApiKey`), and NAS (`BasePaths`, `FreeboxUrl`, `AppId`, `AppToken`, `ApiVersion`).
- Added a `UserSecretsId` to the project file to support secure storage of sensitive configuration in development.

**Documentation**
- Substantially expanded `README.md` with architecture overview, technology stack, implementation progress, project structure, configuration instructions (including User Secrets and environment variables), Freebox app token acquisition, and development guidelines.