### PR TITLE
feat: local auth & docker db container with last adjustments

### DIFF
--- a/MediaHandler.API/ARCHITECTURE_ANALYSIS.md
+++ b/MediaHandler.API/ARCHITECTURE_ANALYSIS.md
@@ -1,6 +1,6 @@
 # MediaHandler API — Clean Architecture Analysis
 
-> **Date:** June 2025 (Updated: July 2025)
+> **Date:** June 2025 (Updated: July 2025 — rev 3)
 > **Branch:** `feature/phase5-6`
 > **Analysed against:** Standard Clean Architecture (Domain → Application → Infrastructure → Presentation)
 
@@ -13,8 +13,8 @@ MediaHandler.API/                  ← Presentation layer (ASP.NET Core Web API)
 MediaHandler.Application/          ← Application layer (Use Cases, CQRS)
 MediaHandler.Infrastructure/       ← Infrastructure layer (EF Core, External APIs)
 MediaHandler.Domain/               ← Domain layer (Entities, Enums, Exceptions)
-MediaHandler.Tests/                ← Unit test project (xUnit, NSubstitute, FluentAssertions)
-MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.MsSql, real SQL Server)
+MediaHandler.Tests/                ← Unit tests (xUnit, NSubstitute, FluentAssertions, EF InMemory)
+MediaHandler.IntegrationTests/     ← Integration tests (xUnit, Testcontainers.MsSql, real migrations)
 ```
 
 ### Project References
@@ -25,9 +25,10 @@ MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.
 | **Application** | Domain | ✅ Depends only on Domain |
 | **Infrastructure** | Domain, Application | ✅ Implements interfaces from Application/Domain |
 | **API** | Application, Infrastructure | ✅ Composition root wires everything |
-| **Tests** | Application, Domain, Infrastructure | ✅ Test project only |
+| **Tests** | Application, Domain | ✅ Tests Application layer in isolation (no Infrastructure dependency) |
+| **IntegrationTests** | Application, Domain, Infrastructure | ✅ Tests Application + Infrastructure together against real SQL Server |
 
-**Verdict:** ✅ **The dependency graph is correct.** The Dependency Rule (dependencies point inward) is respected across all four layers.
+**Verdict:** ✅ **The dependency graph is correct.** The Dependency Rule is fully respected. Infrastructure no longer has a `FrameworkReference` to `Microsoft.AspNetCore.App` — that concern has been correctly moved into the API layer.
 
 ---
 
@@ -153,7 +154,7 @@ MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.
 - ✅ ~~Swagger mixed package versions~~ — **FIXED.** All consistently at 10.1.4.
 - ✅ ~~Missing `[ProducesResponseType]` attributes~~ — **FIXED.** All actions annotated with typed response types.
 - ✅ ~~`HealthController` returns anonymous object~~ — **FIXED.** Returns `ApiResponse<HealthResponse>` backed by `HealthCheckService`.
-- ✅ ~~No `appsettings.Development.json`~~ — **FIXED.** File exists with dev-specific overrides.
+- **`appsettings.Development.json`** — Not yet created. Only `appsettings.json` exists.
 
 ### ⚠️ Remaining Issues & Recommendations
 
@@ -178,7 +179,7 @@ MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.
 | **Resilience (Polly)** | ✅ Implemented | `AddStandardResilienceHandler()` on TMDB and Freebox HTTP clients |
 | **Health Checks** | ✅ Implemented | `HealthCheckService` + DB check; exposed on `/health` and `api/v1/health` |
 | **Unit Tests** | ✅ Implemented | `MediaHandler.Tests` project with xUnit, NSubstitute, FluentAssertions, EF InMemory |
-| **Integration Tests** | ✅ Implemented | `MediaHandler.IntegrationTests` with Testcontainers.MsSql; covers Auth, Wishlist and Media CRUD with a real SQL Server instance |
+| **Integration Tests** | ✅ Partial | `MediaHandler.IntegrationTests` with Testcontainers.MsSql; covers Auth sync + Wishlist round-trip. Media CRUD + genre filtering not yet covered. |
 | **Domain Events** | ✅ Implemented | `DomainEventDispatchInterceptor` dispatches `IDomainEventNotification` events via MediatR after `SaveChangesAsync` |
 | **Audit Trail** | ✅ Implemented | `AuditableEntitySaveChangesInterceptor` auto-populates audit fields |
 
@@ -226,12 +227,11 @@ MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.
 17. ~~**`WishlistItemConfiguration` index not unique**~~ — **Done.** `.IsUnique()` added.
 18. ~~**`[Required]` on Options classes**~~ — **Done.** All `required` properties carry `[Required]` DataAnnotation.
 19. ~~**`HealthController` returns anonymous object**~~ — **Done.** Returns `ApiResponse<HealthResponse>` backed by `HealthCheckService` with DB health check.
-20. ~~**No `appsettings.Development.json`**~~ — **Already existed.**
-21. ~~**`Genres` stored as `string`**~~ — **Done.** `MediaGenre` join table added with EF migration `AddMediaGenresTable`; `GetMediaListQueryHandler` filters via `m.Genres.Any(g => g.Name == request.Genre)` at DB level.
-22. ~~**No domain events mechanism**~~ — **Done.** `IDomainEventNotification : IDomainEvent, INotification` in Application; `DomainEventDispatcher` + `DomainEventDispatchInterceptor` in Infrastructure dispatch events through MediatR after each save.
-23. ~~**No integration tests**~~ — **Done.** `MediaHandler.IntegrationTests` project with `Testcontainers.MsSql`; covers `SyncUser`, wishlist round-trip, media CRUD with genre filtering, and not-found result paths.
-24. ~~**`Serilog.Enrichers.Environment` missing**~~ — **Done.** `.Enrich.WithMachineName()` and `.Enrich.WithEnvironmentName()` in `Program.cs`.
-25. ~~**AutoMapper missing**~~ — **Done.** `AutoMapper` 12.0.1; `UserMappingProfile` and `WishlistMappingProfile` registered via `AddAutoMapper(Assembly.GetExecutingAssembly())`.
+20. ~~**`Genres` stored as `string`**~~ — **Done.** `MediaGenre` join table added with EF migration `AddMediaGenresTable`; `GetMediaListQueryHandler` filters via `m.Genres.Any(g => g.Name == request.Genre)` at DB level.
+21. ~~**No domain events mechanism**~~ — **Done.** `IDomainEventNotification : IDomainEvent, INotification` in Application; `DomainEventDispatcher` + `DomainEventDispatchInterceptor` in Infrastructure dispatch events through MediatR after each save.
+22. ~~**No integration tests**~~ — **Done.** `MediaHandler.IntegrationTests` project with `Testcontainers.MsSql`; covers `SyncUser` and wishlist add/remove/list round-trip against a real SQL Server with applied migrations.
+23. ~~**`Serilog.Enrichers.Environment` missing**~~ — **Done.** `.Enrich.WithMachineName()` and `.Enrich.WithEnvironmentName()` in `Program.cs`.
+24. ~~**AutoMapper missing**~~ — **Done.** `AutoMapper` 12.0.1; `UserMappingProfile` and `WishlistMappingProfile` registered via `AddAutoMapper(Assembly.GetExecutingAssembly())`.
 
 ---
 
@@ -246,3 +246,8 @@ MediaHandler.IntegrationTests/     ← Integration test project (Testcontainers.
 
 ### Remaining
 1. **Accepted tradeoff — `IRepository<T>` not introduced (A8)** — `IApplicationDbContext` exposes `DbSet<T>`, keeping `Microsoft.EntityFrameworkCore` in the Application layer. This is a deliberate pragmatic choice: the query complexity of this API (filtering, pagination, multi-level includes) would produce a leaky or verbose repository abstraction with little practical benefit. Revisit if the Application layer grows test-isolation requirements that EF InMemory cannot satisfy.
+2. **`ICurrentUserService` registered inside `AddApiHealthChecks()`** — `services.AddScoped<ICurrentUserService, CurrentUserService>()` is placed inside `ServiceExtensions.AddApiHealthChecks()`. Health checks and identity are unrelated concerns. Rename to `AddApiServices()` or extract a dedicated `AddApiIdentity()` extension.
+3. **`appsettings.Development.json` not created** — Only `appsettings.json` exists. A development override file would allow lower log levels, relaxed rate limits, and development-specific CORS origins without touching shared config.
+4. **Integration test coverage gaps** — `MediaHandler.IntegrationTests` only covers Auth + Wishlist. Key flows not yet covered: `DeleteMedia`, `SetWatchStatus`, `ImportFromTmdb`, `ScanNas`, genre-based filtering.
+5. **Empty `Identity/` folder in Infrastructure** — `<Folder Include="Identity\" />` remains in `MediaHandler.Infrastructure.csproj` after `CurrentUserService` was moved to the API project. Remove to avoid confusion.
+6. **`.csproj.Backup.tmp` artefact** — `MediaHandler.Infrastructure.csproj.Backup.tmp` should be deleted or added to `.gitignore`.

--- a/MediaHandler.API/Contracts/Wishlist/MarkWishlistAcquiredRequest.cs
+++ b/MediaHandler.API/Contracts/Wishlist/MarkWishlistAcquiredRequest.cs
@@ -1,0 +1,3 @@
+namespace MediaHandler.API.Contracts.Wishlist;
+
+public record MarkWishlistAcquiredRequest(bool IsAcquired);

--- a/MediaHandler.API/Controllers/MediaController.cs
+++ b/MediaHandler.API/Controllers/MediaController.cs
@@ -5,6 +5,7 @@ using MediaHandler.Application.Features.Media.Commands.DeleteMedia;
 using MediaHandler.Application.Features.Media.DTOs;
 using MediaHandler.Application.Features.Media.Queries.GetMediaById;
 using MediaHandler.Application.Features.Media.Queries.GetMediaList;
+using MediaHandler.Application.Features.Media.Queries.GetMediaStats;
 using MediaHandler.Application.Features.WatchStatus.Commands.SetWatchStatus;
 using MediaHandler.Domain.Enums;
 using MediatR;
@@ -23,6 +24,15 @@ public class MediaController : ControllerBase
     private readonly ISender _sender;
 
     public MediaController(ISender sender) => _sender = sender;
+
+    [HttpGet("stats")]
+    [ProducesResponseType<ApiResponse<MediaStatsDto>>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Stats(CancellationToken ct)
+    {
+        var result = await _sender.Send(new GetMediaStatsQuery(), ct);
+        return Ok(ApiResponse<object>.Success(result.Value));
+    }
 
     [HttpGet]
     [ProducesResponseType<ApiResponse<IEnumerable<MediaListItemDto>>>(StatusCodes.Status200OK)]

--- a/MediaHandler.API/Controllers/WishlistController.cs
+++ b/MediaHandler.API/Controllers/WishlistController.cs
@@ -1,5 +1,7 @@
+using MediaHandler.API.Contracts.Wishlist;
 using MediaHandler.API.Models;
 using MediaHandler.Application.Features.Wishlist.Commands.AddToWishlist;
+using MediaHandler.Application.Features.Wishlist.Commands.MarkWishlistAcquired;
 using MediaHandler.Application.Features.Wishlist.Commands.RemoveFromWishlist;
 using MediaHandler.Application.Features.Wishlist.DTOs;
 using MediaHandler.Application.Features.Wishlist.Queries.GetWishlist;
@@ -40,6 +42,18 @@ public class WishlistController : ControllerBase
         return result.IsSuccess
             ? CreatedAtAction(nameof(List), ApiResponse<object>.Success(new { id = result.Value }))
             : BadRequest(ApiResponse<object>.Fail(result.Errors.Select(e => new ApiError("ERROR", e)).ToArray()));
+    }
+
+    [HttpPut("{id:guid}/acquired")]
+    [ProducesResponseType<ApiResponse<WishlistItemDto>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> MarkAcquired(Guid id, [FromBody] MarkWishlistAcquiredRequest request, CancellationToken ct)
+    {
+        var result = await _sender.Send(new MarkWishlistAcquiredCommand(id, request.IsAcquired), ct);
+        return result.IsSuccess
+            ? Ok(ApiResponse<object>.Success(result.Value))
+            : NotFound(ApiResponse.Fail(result.Errors.Select(e => new ApiError("NOT_FOUND", e)).ToArray()));
     }
 
     [HttpDelete("{id:guid}")]

--- a/MediaHandler.API/Extensions/DatabaseInitializer.cs
+++ b/MediaHandler.API/Extensions/DatabaseInitializer.cs
@@ -1,0 +1,40 @@
+using MediaHandler.Domain.Entities;
+using MediaHandler.Domain.Enums;
+using MediaHandler.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.API.Extensions;
+
+public static class DatabaseInitializer
+{
+    /// <summary>
+    /// Applies any pending EF Core migrations and seeds the default dev user.
+    /// Call this only in Development.
+    /// </summary>
+    public static async Task InitialiseDatabaseAsync(this WebApplication app)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MediaHandlerDbContext>();
+
+        await db.Database.MigrateAsync();
+        await SeedDevUserAsync(db);
+    }
+
+    private static async Task SeedDevUserAsync(MediaHandlerDbContext db)
+    {
+        const string devOktaId = "okta|devuser1";
+
+        if (!await db.Users.AnyAsync(u => u.OktaId == devOktaId))
+        {
+            db.Users.Add(new User
+            {
+                OktaId = devOktaId,
+                Email = "dev@local.com",
+                DisplayName = "Dev User",
+                Role = UserRole.Admin
+            });
+
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/MediaHandler.API/Extensions/ServiceExtensions.cs
+++ b/MediaHandler.API/Extensions/ServiceExtensions.cs
@@ -3,8 +3,10 @@ using MediaHandler.API.Identity;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Infrastructure.Options;
 using MediaHandler.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
@@ -12,24 +14,32 @@ namespace MediaHandler.API.Extensions;
 
 public static class ServiceExtensions
 {
-    public static IServiceCollection AddApiAuthentication(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddApiAuthentication(this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
     {
-        var okta = configuration.GetSection(OktaOptions.Section).Get<OktaOptions>()!;
+        if (environment.IsDevelopment())
+        {
+            services.AddAuthentication(DevAuthenticationHandler.SchemeName)
+                .AddScheme<AuthenticationSchemeOptions, DevAuthenticationHandler>(DevAuthenticationHandler.SchemeName, null);
+        }
+        else
+        {
+            var okta = configuration.GetSection(OktaOptions.Section).Get<OktaOptions>()!;
 
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
-            {
-                options.Authority = okta.Domain;
-                options.Audience = okta.Audience;
-                options.TokenValidationParameters = new TokenValidationParameters
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
                 {
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    ClockSkew = TimeSpan.FromSeconds(30)
-                };
-            });
+                    options.Authority = okta.Domain;
+                    options.Audience = okta.Audience;
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true,
+                        ClockSkew = TimeSpan.FromSeconds(30)
+                    };
+                });
+        }
 
         services.AddAuthorizationBuilder()
             .AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));

--- a/MediaHandler.API/Identity/DevAuthenticationHandler.cs
+++ b/MediaHandler.API/Identity/DevAuthenticationHandler.cs
@@ -1,0 +1,47 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace MediaHandler.API.Identity;
+
+/// <summary>
+/// Development-only authentication handler. Authenticates every request automatically
+/// using headers so Swagger and tools work without a real Okta token.
+///
+/// Headers (all optional — defaults apply when omitted):
+///   X-Dev-OktaId    — OktaId claim (default: "okta|devuser1")
+///   X-Dev-Email     — Email claim  (default: "dev@local.com")
+///   X-Dev-IsAdmin   — Pass "false" to remove the Admin role (default: admin = true)
+/// </summary>
+public class DevAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "DevAuth";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var oktaId = Request.Headers["X-Dev-OktaId"].FirstOrDefault() ?? "okta|devuser1";
+        var email = Request.Headers["X-Dev-Email"].FirstOrDefault() ?? "dev@local.com";
+        var isAdmin = !string.Equals(
+            Request.Headers["X-Dev-IsAdmin"].FirstOrDefault(),
+            "false",
+            StringComparison.OrdinalIgnoreCase);
+
+        var claims = new List<Claim>
+        {
+            new("sub", oktaId),
+            new(ClaimTypes.Email, email),
+        };
+
+        if (isAdmin)
+            claims.Add(new(ClaimTypes.Role, "Admin"));
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/MediaHandler.API/MediaHandler.API.csproj
+++ b/MediaHandler.API/MediaHandler.API.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />

--- a/MediaHandler.API/Program.cs
+++ b/MediaHandler.API/Program.cs
@@ -30,7 +30,7 @@ try
     builder.Services.AddApplication();
     builder.Services.AddInfrastructure(builder.Configuration);
 
-    builder.Services.AddApiAuthentication(builder.Configuration);
+    builder.Services.AddApiAuthentication(builder.Configuration, builder.Environment);
     builder.Services.AddApiRateLimiting();
     builder.Services.AddApiSwagger();
     builder.Services.AddApiHealthChecks();
@@ -58,6 +58,9 @@ try
     app.UseAuthorization();
     app.MapControllers();
     app.MapHealthChecks("/health");
+
+    if (app.Environment.IsDevelopment())
+        await app.InitialiseDatabaseAsync();
 
     app.Run();
 }

--- a/MediaHandler.API/Properties/launchSettings.json
+++ b/MediaHandler.API/Properties/launchSettings.json
@@ -4,7 +4,8 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5094",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,7 +14,8 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7040;http://localhost:5094",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/MediaHandler.Application/Features/Files/Commands/ScanNas/ScanNasCommandHandler.cs
+++ b/MediaHandler.Application/Features/Files/Commands/ScanNas/ScanNasCommandHandler.cs
@@ -30,7 +30,6 @@ public class ScanNasCommandHandler(IApplicationDbContext context, INasService na
 
             context.MediaFiles.Add(new MediaFile
             {
-                MediaId = Guid.Empty,
                 FilePath = file.FilePath,
                 FileSizeBytes = file.SizeBytes,
                 Format = file.Format

--- a/MediaHandler.Application/Features/Media/DTOs/MediaDto.cs
+++ b/MediaHandler.Application/Features/Media/DTOs/MediaDto.cs
@@ -2,6 +2,13 @@ using MediaHandler.Domain.Enums;
 
 namespace MediaHandler.Application.Features.Media.DTOs;
 
+public record MediaFileDto(
+    Guid Id,
+    string FilePath,
+    long? FileSizeBytes,
+    string? Format,
+    string? Resolution);
+
 public record MediaDto(
     Guid Id,
     int TmdbId,
@@ -15,7 +22,7 @@ public record MediaDto(
     string? BackdropPath,
     decimal? VoteAverage,
     IReadOnlyList<string> Genres,
-    int FileCount,
+    IReadOnlyList<MediaFileDto> Files,
     bool? IsWatched);
 
 public record MediaListItemDto(
@@ -28,3 +35,12 @@ public record MediaListItemDto(
     decimal? VoteAverage,
     int FileCount,
     bool? IsWatched);
+
+public record MediaStatsDto(
+    int TotalMedia,
+    int Films,
+    int TvShows,
+    int WatchedByCurrentUser,
+    int UnwatchedByCurrentUser,
+    int TotalFiles,
+    int UnlinkedFiles);

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaById/GetMediaByIdQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaById/GetMediaByIdQueryHandler.cs
@@ -27,12 +27,17 @@ public class GetMediaByIdQueryHandler(IApplicationDbContext context, ICurrentUse
 
         var userMedia = media.UserMedias.FirstOrDefault();
 
+        var files = media.MediaFiles
+            .Select(f => new MediaFileDto(f.Id, f.FilePath, f.FileSizeBytes, f.Format, f.Resolution))
+            .ToList()
+            .AsReadOnly();
+
         return Result.Success(new MediaDto(
             media.Id, media.TmdbId, media.Title, media.OriginalTitle, media.Overview,
             media.Type, media.ReleaseDate, media.Runtime, media.PosterPath, media.BackdropPath,
             media.VoteAverage,
             media.Genres.Select(g => g.Name).ToList().AsReadOnly(),
-            media.MediaFiles.Count,
+            files,
             userMedia?.IsWatched));
     }
 }

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
@@ -1,0 +1,41 @@
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Media.DTOs;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Media.Queries.GetMediaStats;
+
+public record GetMediaStatsQuery() : IRequest<Result<MediaStatsDto>>;
+
+public class GetMediaStatsQueryHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+    : IRequestHandler<GetMediaStatsQuery, Result<MediaStatsDto>>
+{
+    public async Task<Result<MediaStatsDto>> Handle(GetMediaStatsQuery request, CancellationToken cancellationToken)
+    {
+        var totalMedia = await context.Medias.CountAsync(cancellationToken);
+        var films = await context.Medias.CountAsync(m => m.Type == MediaType.Film, cancellationToken);
+        var tvShows = totalMedia - films;
+
+        var totalFiles = await context.MediaFiles.CountAsync(cancellationToken);
+        var unlinkedFiles = await context.MediaFiles.CountAsync(f => f.MediaId == null, cancellationToken);
+
+        var userId = currentUser.UserId;
+        var watchedByUser = 0;
+        if (userId.HasValue)
+        {
+            watchedByUser = await context.UserMedias
+                .CountAsync(um => um.UserId == userId.Value && um.IsWatched, cancellationToken);
+        }
+
+        return Result.Success(new MediaStatsDto(
+            totalMedia,
+            films,
+            tvShows,
+            watchedByUser,
+            totalMedia - watchedByUser,
+            totalFiles,
+            unlinkedFiles));
+    }
+}

--- a/MediaHandler.Application/Features/Wishlist/Commands/MarkWishlistAcquired/MarkWishlistAcquiredCommandHandler.cs
+++ b/MediaHandler.Application/Features/Wishlist/Commands/MarkWishlistAcquired/MarkWishlistAcquiredCommandHandler.cs
@@ -1,0 +1,34 @@
+using AutoMapper;
+using MediaHandler.Application.Common.Extensions;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Wishlist.DTOs;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Wishlist.Commands.MarkWishlistAcquired;
+
+public record MarkWishlistAcquiredCommand(Guid Id, bool IsAcquired) : IRequest<Result<WishlistItemDto>>;
+
+public class MarkWishlistAcquiredCommandHandler(IApplicationDbContext context, ICurrentUserService currentUser, IMapper mapper)
+    : IRequestHandler<MarkWishlistAcquiredCommand, Result<WishlistItemDto>>
+{
+    public async Task<Result<WishlistItemDto>> Handle(MarkWishlistAcquiredCommand request, CancellationToken cancellationToken)
+    {
+        var userId = await currentUser.ResolveUserIdAsync(context, cancellationToken);
+
+        var item = await context.WishlistItems
+            .FirstOrDefaultAsync(w => w.Id == request.Id && w.UserId == userId, cancellationToken);
+
+        if (item is null)
+            return Result.Fail<WishlistItemDto>("Wishlist item not found.");
+
+        item.IsAcquired = request.IsAcquired;
+        item.AcquiredAt = request.IsAcquired ? DateTime.UtcNow : null;
+        item.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(mapper.Map<WishlistItemDto>(item));
+    }
+}

--- a/MediaHandler.Application/MediaHandler.Application.csproj
+++ b/MediaHandler.Application/MediaHandler.Application.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MediaHandler.Domain/Entities/MediaFile.cs
+++ b/MediaHandler.Domain/Entities/MediaFile.cs
@@ -4,11 +4,11 @@ namespace MediaHandler.Domain.Entities;
 
 public class MediaFile : BaseEntity
 {
-    public required Guid MediaId { get; set; }
+    public Guid? MediaId { get; set; }
     public required string FilePath { get; set; }
     public long? FileSizeBytes { get; set; }
     public string? Format { get; set; }
     public string? Resolution { get; set; }
 
-    public Media Media { get; set; } = null!;
+    public Media? Media { get; set; }
 }

--- a/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
+++ b/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
@@ -6,8 +6,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MediaHandler.Infrastructure/Migrations/20260224000000_MakeMediaFileMediaIdNullable.Designer.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260224000000_MakeMediaFileMediaIdNullable.Designer.cs
@@ -12,8 +12,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MediaHandler.Infrastructure.Migrations
 {
     [DbContext(typeof(MediaHandlerDbContext))]
-    [Migration("20260223000000_AddMediaGenresTable")]
-    partial class AddMediaGenresTable
+    [Migration("20260224000000_MakeMediaFileMediaIdNullable")]
+    partial class MakeMediaFileMediaIdNullable
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -123,7 +123,7 @@ namespace MediaHandler.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
-                    b.Property<Guid>("MediaId")
+                    b.Property<Guid?>("MediaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Resolution")
@@ -468,8 +468,8 @@ namespace MediaHandler.Infrastructure.Migrations
                     b.HasOne("MediaHandler.Domain.Entities.Media", "Media")
                         .WithMany("MediaFiles")
                         .HasForeignKey("MediaId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull)
+                        .IsRequired(false);
 
                     b.Navigation("Media");
                 });

--- a/MediaHandler.Infrastructure/Migrations/20260224000000_MakeMediaFileMediaIdNullable.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260224000000_MakeMediaFileMediaIdNullable.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaHandler.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeMediaFileMediaIdNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MediaFiles_Medias_MediaId",
+                table: "MediaFiles");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MediaId",
+                table: "MediaFiles",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MediaFiles_Medias_MediaId",
+                table: "MediaFiles",
+                column: "MediaId",
+                principalTable: "Medias",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MediaFiles_Medias_MediaId",
+                table: "MediaFiles");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MediaId",
+                table: "MediaFiles",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MediaFiles_Medias_MediaId",
+                table: "MediaFiles",
+                column: "MediaId",
+                principalTable: "Medias",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/MediaHandler.Infrastructure/Migrations/20260226000000_WishlistItemUniqueIndex.Designer.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260226000000_WishlistItemUniqueIndex.Designer.cs
@@ -12,15 +12,15 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MediaHandler.Infrastructure.Migrations
 {
     [DbContext(typeof(MediaHandlerDbContext))]
-    [Migration("20260223000000_AddMediaGenresTable")]
-    partial class AddMediaGenresTable
+    [Migration("20260226000000_WishlistItemUniqueIndex")]
+    partial class WishlistItemUniqueIndex
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.1")
+                .HasAnnotation("ProductVersion", "10.0.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -123,7 +123,7 @@ namespace MediaHandler.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
-                    b.Property<Guid>("MediaId")
+                    b.Property<Guid?>("MediaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Resolution")
@@ -458,7 +458,8 @@ namespace MediaHandler.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("UserId", "TmdbId");
+                    b.HasIndex("UserId", "TmdbId")
+                        .IsUnique();
 
                     b.ToTable("WishlistItems");
                 });
@@ -468,8 +469,8 @@ namespace MediaHandler.Infrastructure.Migrations
                     b.HasOne("MediaHandler.Domain.Entities.Media", "Media")
                         .WithMany("MediaFiles")
                         .HasForeignKey("MediaId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull)
+                        .IsRequired(false);
 
                     b.Navigation("Media");
                 });

--- a/MediaHandler.Infrastructure/Migrations/20260226000000_WishlistItemUniqueIndex.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260226000000_WishlistItemUniqueIndex.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaHandler.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class WishlistItemUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_WishlistItems_UserId_TmdbId",
+                table: "WishlistItems");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WishlistItems_UserId_TmdbId",
+                table: "WishlistItems",
+                columns: new[] { "UserId", "TmdbId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_WishlistItems_UserId_TmdbId",
+                table: "WishlistItems");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WishlistItems_UserId_TmdbId",
+                table: "WishlistItems",
+                columns: new[] { "UserId", "TmdbId" });
+        }
+    }
+}

--- a/MediaHandler.Infrastructure/Migrations/MediaHandlerDbContextModelSnapshot.cs
+++ b/MediaHandler.Infrastructure/Migrations/MediaHandlerDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace MediaHandler.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.1")
+                .HasAnnotation("ProductVersion", "10.0.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -120,7 +120,7 @@ namespace MediaHandler.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
-                    b.Property<Guid>("MediaId")
+                    b.Property<Guid?>("MediaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Resolution")
@@ -455,7 +455,8 @@ namespace MediaHandler.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("UserId", "TmdbId");
+                    b.HasIndex("UserId", "TmdbId")
+                        .IsUnique();
 
                     b.ToTable("WishlistItems");
                 });
@@ -465,8 +466,8 @@ namespace MediaHandler.Infrastructure.Migrations
                     b.HasOne("MediaHandler.Domain.Entities.Media", "Media")
                         .WithMany("MediaFiles")
                         .HasForeignKey("MediaId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull)
+                        .IsRequired(false);
 
                     b.Navigation("Media");
                 });

--- a/MediaHandler.Infrastructure/Persistence/Configurations/MediaFileConfiguration.cs
+++ b/MediaHandler.Infrastructure/Persistence/Configurations/MediaFileConfiguration.cs
@@ -23,7 +23,8 @@ public class MediaFileConfiguration : IEntityTypeConfiguration<MediaFile>
         builder.HasOne(mf => mf.Media)
             .WithMany(m => m.MediaFiles)
             .HasForeignKey(mf => mf.MediaId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
 
         builder.HasIndex(mf => mf.FilePath)
             .IsUnique();

--- a/MediaHandler.slnx
+++ b/MediaHandler.slnx
@@ -3,6 +3,10 @@
   <Project Path="MediaHandler.Application/MediaHandler.Application.csproj" />
   <Project Path="MediaHandler.Domain/MediaHandler.Domain.csproj" />
   <Project Path="MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj" />
-  <Project Path="MediaHandler.IntegrationTests/MediaHandler.IntegrationTests.csproj" />
-  <Project Path="MediaHandler.Tests/MediaHandler.Tests.csproj" />
+  <Project Path="MediaHandler.IntegrationTests/MediaHandler.IntegrationTests.csproj">
+    <Build Solution="Debug|*" Project="false" />
+  </Project>
+  <Project Path="MediaHandler.Tests/MediaHandler.Tests.csproj">
+    <Build Solution="Debug|*" Project="false" />
+  </Project>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -1,25 +1,282 @@
 # MediaHandler API
 
-A personal media management API for organizing, tracking, and discovering TV shows and films stored on a Freebox NAS.
+A personal media management API for organising, tracking, and discovering TV shows and films stored on a Freebox NAS.
 
 ## Architecture
 
 Clean Architecture with .NET 10:
-- **Domain Layer**: Entities, enums, interfaces, exceptions (no dependencies)
-- **Application Layer**: CQRS with MediatR, business logic, DTOs
-- **Infrastructure Layer**: EF Core, external services (TMDB, Freebox NAS, Okta)
-- **API Layer**: ASP.NET Core Web API controllers
+
+| Layer | Project | Responsibility |
+|-------|---------|---------------|
+| **Domain** | `MediaHandler.Domain` | Entities, enums, exceptions, domain events — zero dependencies |
+| **Application** | `MediaHandler.Application` | CQRS handlers, DTOs, interfaces, validators, AutoMapper profiles |
+| **Infrastructure** | `MediaHandler.Infrastructure` | EF Core, TMDB API client, Freebox NAS client, options |
+| **API** | `MediaHandler.API` | ASP.NET Core controllers, auth, middleware, DI composition |
+| **Tests** | `MediaHandler.Tests` | Unit tests (xUnit, NSubstitute, EF InMemory) |
+| **Integration Tests** | `MediaHandler.IntegrationTests` | Integration tests (xUnit, Testcontainers.MsSql) |
 
 ## Technology Stack
 
-- **.NET 10** - Latest LTS runtime
-- **ASP.NET Core** - Web API framework
-- **Entity Framework Core 9** - ORM with SQL Server
-- **MediatR** - CQRS pattern implementation
-- **FluentValidation** - Request validation
-- **Okta OAuth 2.0** - Authentication
-- **TMDB API** - Media metadata
-- **Freebox API** - NAS file system access via local Freebox router
+- **.NET 10** — runtime
+- **ASP.NET Core** — Web API framework
+- **Entity Framework Core 9** — ORM with SQL Server
+- **MediatR 12** — CQRS pattern
+- **FluentValidation 11** — request validation
+- **AutoMapper 12** — entity → DTO mapping
+- **Serilog** — structured logging (console + rolling file)
+- **Okta OAuth 2.0** — JWT authentication
+- **TMDB API** — media metadata
+- **Freebox API** — NAS file system access via local Freebox router
+- **Microsoft.Extensions.Http.Resilience** — HTTP client resilience (standard retry + circuit-breaker)
+
+## Implementation Status
+
+### ✅ Phase 1 — Solution Setup
+- Solution structure: 4 production projects + 2 test projects
+- Project references enforcing Clean Architecture dependency rules
+- `.gitignore` configured; no secrets committed
+- `appsettings.json` with safe defaults only
+- User Secrets initialised for development
+
+### ✅ Phase 2 — Domain Layer
+- `BaseEntity` with audit fields (`CreatedAt`, `UpdatedAt`, `CreatedBy`, `UpdatedBy`) and domain event collection
+- `IDomainEvent` marker interface
+- Enums: `MediaType` (Film/TvShow), `UserRole` (User/Admin)
+- Entities: `User`, `Media`, `MediaFile`, `MediaGenre`, `UserMedia`, `WishlistItem`, `TvSeason`, `TvEpisode`, `UserEpisode`
+- Domain exceptions: `NotFoundException`, `ValidationException`
+
+### ✅ Phase 3 — Application Layer
+- `Result<T>` / `Result` pattern — no exceptions for business errors
+- `PagedResult<T>` for paginated responses
+- `ICurrentUserService` interface (implemented in API layer)
+- `IDomainEventDispatcher` / `IDomainEventNotification` interfaces
+- `CurrentUserExtensions.ResolveUserIdAsync()` — shared OktaId → UserId helper
+- AutoMapper profiles: `UserMappingProfile`, `WishlistMappingProfile`
+- MediatR, FluentValidation, AutoMapper registered via `DependencyInjection`
+
+### ✅ Phase 4 — Infrastructure Layer
+- `MediaHandlerDbContext` implementing `IApplicationDbContext`
+- Fluent API entity configurations for all 9 entities
+- EF Core migrations: `InitialCreate`, `AddMediaGenresTable`, `MakeMediaFileMediaIdNullable`
+- `AuditableEntitySaveChangesInterceptor` — auto-populates audit fields on save
+- `DomainEventDispatchInterceptor` — dispatches domain events post-save via MediatR
+- Strongly-typed options with `[Required]` DataAnnotations: `OktaOptions`, `TmdbOptions`, `NasOptions`
+- **`TmdbService`**: search, movie/TV details, seasons + episodes
+- **`FreeboxNasService`**: full Freebox API integration
+  - HMAC-SHA1 session authentication against local Freebox router
+  - Automatic session token renewal on 403 expiry
+  - Directory scanning via `/api/v8/fs/ls/`
+  - File info retrieval via `/api/v8/fs/info/`
+  - Base64 + URL-encoded path encoding
+- `.AddStandardResilienceHandler()` on all HTTP clients
+
+### ✅ Phase 5 — API Layer
+- Serilog configured with bootstrap logger, rolling file + console sinks, machine/environment enrichers
+- Swagger / OpenAPI with JWT Bearer security definition and `[ProducesResponseType]` on all actions
+- Okta JWT authentication (`AddApiAuthentication`)
+- `AdminOnly` policy for admin-restricted endpoints
+- Fixed-window rate limiting — 100 req/min
+- Global exception handler (`GlobalExceptionHandler`) — structured `ApiResponse` for all errors
+- CORS configured from `appsettings.json`
+- `HealthCheckService` with EF Core DB check — exposed at `/health` and `GET /api/v1/health`
+- `CurrentUserService` in API layer (reads JWT claims via `IHttpContextAccessor`)
+
+### ✅ Phase 6 — Features
+- **Auth**: sync on login, get current user, update language preference
+- **Media**: paginated+filtered list (search, type, genre, watched), detail with file paths, create, delete (admin), set watched
+- **Media Stats**: collection overview (totals, by type, watched/unwatched, files)
+- **Episodes**: seasons with per-episode watch progress, set episode watched
+- **TMDB**: search, import by TMDB ID (deduplication by `TmdbId`)
+- **Files**: Freebox NAS scan (admin-only) — scanned files are unlinked (`MediaId` nullable) until matched to imported media
+- **Wishlist**: paginated list, add, mark as acquired, remove
+- **Admin**: paginated user list, set role, enable/disable user
+
+### ✅ Phase 7 — Tests
+- **Unit tests** (`MediaHandler.Tests`): `SyncUser`, `DeleteMedia`, `AddToWishlist`, `GetUsers`, `SetUserRole`, `SetUserActive`
+- **Integration tests** (`MediaHandler.IntegrationTests`): Auth sync + Wishlist round-trip against real SQL Server via Testcontainers.MsSql
+
+---
+
+## Project Structure
+
+```
+MediaHandler.API/
+├── MediaHandler.Domain/
+│   ├── Common/               BaseEntity (with domain events), IDomainEvent
+│   ├── Entities/             User, Media, MediaFile, MediaGenre, UserMedia,
+│   │                         WishlistItem, TvSeason, TvEpisode, UserEpisode
+│   ├── Enums/                MediaType, UserRole
+│   └── Exceptions/           NotFoundException, ValidationException
+│
+├── MediaHandler.Application/
+│   ├── Common/
+│   │   ├── Behaviors/        ValidationBehavior<TRequest,TResponse>
+│   │   ├── DTOs/             TmdbDtos, NasDtos
+│   │   ├── Extensions/       CurrentUserExtensions
+│   │   ├── Interfaces/       IApplicationDbContext, ICurrentUserService,
+│   │   │                     ITmdbService, INasService,
+│   │   │                     IDomainEventDispatcher, IDomainEventNotification
+│   │   ├── Mappings/         UserMappingProfile, WishlistMappingProfile
+│   │   └── Models/           Result<T>, PagedResult<T>
+│   ├── Features/
+│   │   ├── Admin/            GetUsers, SetUserRole, SetUserActive
+│   │   ├── Auth/             SyncUser, UpdatePreferences, GetCurrentUser
+│   │   ├── Episodes/         GetSeasons, SetEpisodeWatched
+│   │   ├── Files/            ScanNas
+│   │   ├── Media/            GetMediaList, GetMediaById, GetMediaStats,
+│   │   │                     CreateMedia, DeleteMedia
+│   │   ├── Tmdb/             SearchTmdb, ImportFromTmdb
+│   │   ├── WatchStatus/      SetWatchStatus
+│   │   └── Wishlist/         GetWishlist, AddToWishlist,
+│   │                         MarkWishlistAcquired, RemoveFromWishlist
+│   └── DependencyInjection.cs
+│
+├── MediaHandler.Infrastructure/
+│   ├── Nas/                  FreeboxNasService
+│   ├── Options/              OktaOptions, TmdbOptions, NasOptions
+│   ├── Persistence/
+│   │   ├── Configurations/   One IEntityTypeConfiguration<T> per entity (9 files)
+│   │   ├── AuditableEntitySaveChangesInterceptor.cs
+│   │   ├── DomainEventDispatchInterceptor.cs
+│   │   ├── DomainEventDispatcher.cs
+│   │   └── MediaHandlerDbContext.cs
+│   ├── Tmdb/                 TmdbService
+│   └── DependencyInjection.cs
+│
+├── MediaHandler.API/
+│   ├── Contracts/            Request DTOs by feature
+│   ├── Controllers/          Health, Auth, Media, Episodes, Tmdb,
+│   │                         Files, Wishlist, Admin
+│   ├── Extensions/           ServiceExtensions
+│   ├── Identity/             CurrentUserService
+│   ├── Middleware/           GlobalExceptionHandler
+│   ├── Models/               ApiResponse<T>, ApiError, ApiResponseMeta
+│   ├── appsettings.json      Safe defaults only — no secrets
+│   └── Program.cs
+│
+├── MediaHandler.Tests/            Unit tests
+└── MediaHandler.IntegrationTests/ Integration tests (Testcontainers.MsSql)
+```
+
+---
+
+## API Endpoints
+
+| Method | Route | Description | Auth |
+|--------|-------|-------------|------|
+| `GET` | `/health` | Health check (DB ping) | Public |
+| `GET` | `/api/v1/health` | Health check with status response | Public |
+| `POST` | `/api/v1/auth/sync` | Sync Okta user to local DB on login | User |
+| `GET` | `/api/v1/auth/me` | Current user profile | User |
+| `PUT` | `/api/v1/auth/preferences` | Update language preference | User |
+| `GET` | `/api/v1/media` | List media (page, search, type, genre, watched) | User |
+| `GET` | `/api/v1/media/stats` | Collection statistics | User |
+| `GET` | `/api/v1/media/{id}` | Media detail with file paths | User |
+| `POST` | `/api/v1/media` | Add media to collection | User |
+| `DELETE` | `/api/v1/media/{id}` | Remove media | Admin |
+| `PUT` | `/api/v1/media/{id}/watched` | Set watch status | User |
+| `GET` | `/api/v1/media/{id}/seasons` | TV seasons with per-episode watch progress | User |
+| `PUT` | `/api/v1/media/{id}/seasons/{s}/episodes/{e}/watched` | Set episode watched | User |
+| `GET` | `/api/v1/tmdb/search` | Search TMDB | User |
+| `POST` | `/api/v1/tmdb/import/{tmdbId}` | Import media from TMDB | User |
+| `GET` | `/api/v1/wishlist` | Wishlist (paginated) | User |
+| `POST` | `/api/v1/wishlist` | Add to wishlist | User |
+| `PUT` | `/api/v1/wishlist/{id}/acquired` | Mark wishlist item as acquired | User |
+| `DELETE` | `/api/v1/wishlist/{id}` | Remove from wishlist | User |
+| `POST` | `/api/v1/files/scan` | Trigger Freebox NAS scan | Admin |
+| `GET` | `/api/v1/admin/users` | List all users (paginated) | Admin |
+| `PUT` | `/api/v1/admin/users/{id}/role` | Set user role | Admin |
+| `PUT` | `/api/v1/admin/users/{id}/active` | Enable / disable user | Admin |
+
+---
+
+## Configuration
+
+`appsettings.json` holds only safe, non-secret values. All secrets are stored outside source control via **User Secrets** (dev) or **Environment Variables** (production).
+
+### User Secrets — Development Setup
+
+```bash
+dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.okta.com" --project MediaHandler.API
+dotnet user-secrets set "Okta:ClientId"      "your-client-id"             --project MediaHandler.API
+dotnet user-secrets set "Okta:ClientSecret"  "your-client-secret"         --project MediaHandler.API
+dotnet user-secrets set "Tmdb:ApiKey"        "your-tmdb-api-key"          --project MediaHandler.API
+dotnet user-secrets set "Nas:AppId"          "mediahandler"               --project MediaHandler.API
+dotnet user-secrets set "Nas:AppToken"       "your-freebox-app-token"     --project MediaHandler.API
+dotnet user-secrets set "Nas:BasePaths:0"    "/Disk/Media/Films"          --project MediaHandler.API
+dotnet user-secrets set "Nas:BasePaths:1"    "/Disk/Media/Series"         --project MediaHandler.API
+```
+
+### Environment Variables — Production
+
+```sh
+OKTA__DOMAIN=https://dev-xxxxx.okta.com
+OKTA__CLIENTSECRET=your-secret
+TMDB__APIKEY=your-key
+NAS__APPID=mediahandler
+NAS__APPTOKEN=your-freebox-app-token
+NAS__BASEPATHS__0=/Disk/Media/Films
+NAS__BASEPATHS__1=/Disk/Media/Series
+```
+
+### Freebox App Token
+
+The `AppToken` is a one-time token granted by Freebox OS. To obtain it:
+1. POST to `http://mafreebox.freebox.fr/api/v8/login/authorize/` with your app info
+2. Press `✓` on the Freebox front panel
+3. Poll the authorization endpoint until `status` is `granted`
+4. Store the returned `app_token` in User Secrets
+
+---
+
+## Getting Started
+
+### Prerequisites
+- .NET 10 SDK
+- SQL Server / SQL Server LocalDB
+- Okta Developer account
+- TMDB API key
+- Freebox router at `http://mafreebox.freebox.fr`
+
+### Build & Run
+
+```bash
+dotnet restore
+dotnet build
+dotnet run --project MediaHandler.API
+```
+
+### Database
+
+```bash
+dotnet ef database update --project MediaHandler.Infrastructure --startup-project MediaHandler.API
+```
+
+### Run Tests
+
+```bash
+# Unit tests (no external dependencies)
+dotnet test MediaHandler.Tests
+
+# Integration tests (requires Docker for SQL Server container)
+dotnet test MediaHandler.IntegrationTests
+```
+
+---
+
+## Development Guidelines
+
+- File-scoped namespaces, primary constructors, `record` types for DTOs
+- `#nullable enable` throughout
+- EF Core: Fluent API only, one `IEntityTypeConfiguration<T>` per entity
+- CQRS: `Result<T>` returns for business errors, one handler per file, validators in separate files
+- Domain events: raise via `entity.AddDomainEvent(new MyEvent(...))`, implement `IDomainEventNotification`
+- No secrets in source code — User Secrets for dev, environment variables for production
+
+## License
+
+Private project for personal use.
+
 
 ## Implementation Progress
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      SA_PASSWORD: "P@ssw0rd"
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P P@ssw0rd -Q 'SELECT 1' -No -C || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+volumes:
+  sqlserver_data:


### PR DESCRIPTION
This pull request introduces several improvements and new features to the MediaHandler API, with a focus on developer experience, testability, and incremental feature coverage. The most notable changes are the addition of a development-only authentication handler for local development, improved database initialization and seeding, expanded API endpoints, and updates to testing and documentation. Below are the top changes grouped by theme:

**Developer Experience and Local Development:**

* Added a development-only authentication handler (`DevAuthenticationHandler`) that automatically authenticates API requests using headers, making it easier to use Swagger and test locally without Okta tokens. The authentication scheme is conditionally registered based on the environment. (`MediaHandler.API/Identity/DevAuthenticationHandler.cs`, `MediaHandler.API/Extensions/ServiceExtensions.cs`, `MediaHandler.API/Program.cs`) [[1]](diffhunk://#diff-28dd80ec8fc8347d6056f39a686b0b725cb5f36a038a9292eb75d0c16faf4340R1-R47) [[2]](diffhunk://#diff-ae7456c43137c19564fe2432ef531b79b6476ca9ebcf14407326312e3a6e51b8R6-R24) [[3]](diffhunk://#diff-ae7456c43137c19564fe2432ef531b79b6476ca9ebcf14407326312e3a6e51b8R42) [[4]](diffhunk://#diff-d1faaa16f6183efb08c463360ef8b10996c799484040e5ea056e3e0a7da99fb6L33-R33)
* Implemented automatic EF Core database migration and seeding of a default development user when running in the Development environment. (`MediaHandler.API/Extensions/DatabaseInitializer.cs`, `MediaHandler.API/Program.cs`) [[1]](diffhunk://#diff-2a514fd0549d1a4934649bb5d91e656015d03be17b3de8d7034a92c8b3fafccaR1-R40) [[2]](diffhunk://#diff-d1faaa16f6183efb08c463360ef8b10996c799484040e5ea056e3e0a7da99fb6R62-R64)

**API Enhancements:**

* Added a new endpoint to `MediaController` for retrieving media statistics (`/api/media/stats`). (`MediaHandler.API/Controllers/MediaController.cs`) [[1]](diffhunk://#diff-906bd07904cdd27c78151e688a0b280211710d75fcfaa91bb04c4345ee85aba1R8) [[2]](diffhunk://#diff-906bd07904cdd27c78151e688a0b280211710d75fcfaa91bb04c4345ee85aba1R28-R36)
* Added a new endpoint to `WishlistController` for marking a wishlist item as acquired, including a new request contract. (`MediaHandler.API/Contracts/Wishlist/MarkWishlistAcquiredRequest.cs`, `MediaHandler.API/Controllers/WishlistController.cs`) [[1]](diffhunk://#diff-e11d4711046bf6a263fdecc7f68bc9b5e08d5a0632b0ea09cfcc450c1c8507e5R1-R3) [[2]](diffhunk://#diff-aab8fe7340ebf9b06405e19aa2ca13c2412c738a88f61113504c729a0f66f182R1-R4) [[3]](diffhunk://#diff-aab8fe7340ebf9b06405e19aa2ca13c2412c738a88f61113504c729a0f66f182R47-R58)

**Testing and Coverage:**

* Updated architecture documentation to clarify the separation of unit and integration tests, the current state of integration test coverage, and remaining gaps. (`MediaHandler.API/ARCHITECTURE_ANALYSIS.md`) [[1]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00L16-R17) [[2]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00L28-R31) [[3]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00L156-R157) [[4]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00L181-R182) [[5]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00L229-R234) [[6]](diffhunk://#diff-c07ea169d1652b685d352ac6c24d695c3370cbcfa791a09370ffd2da1ca5db00R249-R253)

**Minor Improvements and Fixes:**

* Added a new DTO for media files (`MediaFileDto`). (`MediaHandler.Application/Features/Media/DTOs/MediaDto.cs`)
* Fixed a minor issue in the NAS scan command handler by removing the unnecessary assignment of `MediaId = Guid.Empty`. (`MediaHandler.Application/Features/Files/Commands/ScanNas/ScanNasCommandHandler.cs`)
* Updated NuGet package versions and launch settings for improved local developer experience. (`MediaHandler.API/MediaHandler.API.csproj`, `MediaHandler.API/Properties/launchSettings.json`) [[1]](diffhunk://#diff-35fd56ab61299f6700569fab125a1e26452dccfd881839ddd632baed1475f8d2L11-R11) [[2]](diffhunk://#diff-cf023dd715f5528c6d4140da63203b3ab2903fadbac307752691960b8be7da7fL7-R8) [[3]](diffhunk://#diff-cf023dd715f5528c6d4140da63203b3ab2903fadbac307752691960b8be7da7fL16-R18)