### PR TITLE
Fix/api start

### DIFF
--- a/MediaHandler.API/Extensions/DatabaseInitializer.cs
+++ b/MediaHandler.API/Extensions/DatabaseInitializer.cs
@@ -16,7 +16,18 @@ public static class DatabaseInitializer
         using var scope = app.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MediaHandlerDbContext>();
 
-        await db.Database.MigrateAsync();
+        if (!await db.Database.CanConnectAsync())
+        {
+            // Database does not exist yet — create it by applying all migrations.
+            await db.Database.MigrateAsync();
+        }
+        else
+        {
+            var pending = await db.Database.GetPendingMigrationsAsync();
+            if (pending.Any())
+                await db.Database.MigrateAsync();
+        }
+
         await SeedDevUserAsync(db);
     }
 

--- a/MediaHandler.API/Extensions/ServiceExtensions.cs
+++ b/MediaHandler.API/Extensions/ServiceExtensions.cs
@@ -28,7 +28,8 @@ public static class ServiceExtensions
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
-                    options.Authority = okta.Domain;
+                    // Auth0 requires a trailing slash on the authority URL for OIDC discovery
+                    options.Authority = okta.Domain.TrimEnd('/') + '/';
                     options.Audience = okta.Audience;
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
@@ -36,7 +37,9 @@ public static class ServiceExtensions
                         ValidateAudience = true,
                         ValidateLifetime = true,
                         ValidateIssuerSigningKey = true,
-                        ClockSkew = TimeSpan.FromSeconds(30)
+                        ClockSkew = TimeSpan.FromSeconds(30),
+                        // Auth0 places roles in a namespaced custom claim
+                        RoleClaimType = "https://mediahandler.com/roles"
                     };
                 });
         }
@@ -81,7 +84,7 @@ public static class ServiceExtensions
                 Type = SecuritySchemeType.Http,
                 Scheme = "bearer",
                 BearerFormat = "JWT",
-                Description = "Enter your Okta JWT token"
+                Description = "Enter your Auth0 JWT token"
             });
 
             options.AddSecurityRequirement(doc => new OpenApiSecurityRequirement

--- a/MediaHandler.API/Identity/CurrentUserService.cs
+++ b/MediaHandler.API/Identity/CurrentUserService.cs
@@ -6,26 +6,10 @@ namespace MediaHandler.API.Identity;
 
 public class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService
 {
+    public string? Email => httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.Email);
 
-    public Guid? UserId
-    {
-        get
-        {
-            var userIdClaim = httpContextAccessor.HttpContext?.User?.FindFirst("sub")?.Value;
-            return userIdClaim != null && Guid.TryParse(userIdClaim, out var userId) ? userId : null;
-        }
-    }
+    public string? OktaId => httpContextAccessor.HttpContext?.User?.FindFirstValue("sub");
 
-    public string? Email => httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Email)?.Value;
-
-    public string? OktaId => httpContextAccessor.HttpContext?.User?.FindFirst("sub")?.Value;
-
-    public bool IsAdmin
-    {
-        get
-        {
-            var roleClaim = httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Role)?.Value;
-            return roleClaim == UserRole.Admin.ToString();
-        }
-    }
+    public bool IsAdmin =>
+        httpContextAccessor.HttpContext?.User?.IsInRole(UserRole.Admin.ToString()) ?? false;
 }

--- a/MediaHandler.API/Identity/DevAuthenticationHandler.cs
+++ b/MediaHandler.API/Identity/DevAuthenticationHandler.cs
@@ -23,7 +23,7 @@ public class DevAuthenticationHandler(
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        var oktaId = Request.Headers["X-Dev-OktaId"].FirstOrDefault() ?? "okta|devuser1";
+        var oktaId = Request.Headers["X-Dev-OktaId"].FirstOrDefault() ?? "auth0|devuser1";
         var email = Request.Headers["X-Dev-Email"].FirstOrDefault() ?? "dev@local.com";
         var isAdmin = !string.Equals(
             Request.Headers["X-Dev-IsAdmin"].FirstOrDefault(),

--- a/MediaHandler.API/appsettings.json
+++ b/MediaHandler.API/appsettings.json
@@ -17,7 +17,7 @@
     }
   },
   "AllowedHosts": "*",
-  "AllowedOrigins": [ "http://localhost:3000" ],
+  "AllowedOrigins": [ "http://localhost:3000", "http://localhost:4200" ],
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=MediaHandler;Trusted_Connection=True;MultipleActiveResultSets=true"
   },

--- a/MediaHandler.Application/Common/Interfaces/ICurrentUserService.cs
+++ b/MediaHandler.Application/Common/Interfaces/ICurrentUserService.cs
@@ -2,7 +2,6 @@ namespace MediaHandler.Application.Common.Interfaces;
 
 public interface ICurrentUserService
 {
-    Guid? UserId { get; }
     string? Email { get; }
     string? OktaId { get; }
     bool IsAdmin { get; }

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaById/GetMediaByIdQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaById/GetMediaByIdQueryHandler.cs
@@ -13,7 +13,12 @@ public class GetMediaByIdQueryHandler(IApplicationDbContext context, ICurrentUse
 {
     public async Task<Result<MediaDto>> Handle(GetMediaByIdQuery request, CancellationToken cancellationToken)
     {
-        var userId = currentUser.UserId;
+        var userId = currentUser.OktaId is not null
+            ? await context.Users
+                .Where(u => u.OktaId == currentUser.OktaId)
+                .Select(u => (Guid?)u.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+            : null;
 
         var media = await context.Medias
             .AsNoTracking()

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
@@ -21,7 +21,13 @@ public class GetMediaStatsQueryHandler(IApplicationDbContext context, ICurrentUs
         var totalFiles = await context.MediaFiles.CountAsync(cancellationToken);
         var unlinkedFiles = await context.MediaFiles.CountAsync(f => f.MediaId == null, cancellationToken);
 
-        var userId = currentUser.UserId;
+        var userId = currentUser.OktaId is not null
+            ? await context.Users
+                .Where(u => u.OktaId == currentUser.OktaId)
+                .Select(u => (Guid?)u.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+            : null;
+
         var watchedByUser = 0;
         if (userId.HasValue)
         {

--- a/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
+++ b/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
@@ -1,6 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Compile Remove="Identity\**" />
+    <EmbeddedResource Remove="Identity\**" />
+    <None Remove="Identity\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MediaHandler.Domain\MediaHandler.Domain.csproj" />
     <ProjectReference Include="..\MediaHandler.Application\MediaHandler.Application.csproj" />
   </ItemGroup>
@@ -15,10 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Identity\" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MediaHandler.IntegrationTests/Features/Auth/AuthAndWishlistIntegrationTests.cs
+++ b/MediaHandler.IntegrationTests/Features/Auth/AuthAndWishlistIntegrationTests.cs
@@ -49,7 +49,6 @@ public class AuthAndWishlistIntegrationTests : IntegrationTestBase
 
         var currentUser = Substitute.For<ICurrentUserService>();
         currentUser.OktaId.Returns("okta|wish1");
-        currentUser.UserId.Returns((Guid?)user.Id);
 
         var addHandler = new AddToWishlistCommandHandler(DbContext, currentUser);
         var addResult = await addHandler.Handle(

--- a/MediaHandler.postman_collection.json
+++ b/MediaHandler.postman_collection.json
@@ -1,0 +1,470 @@
+{
+  "info": {
+    "name": "MediaHandler API",
+    "_postman_id": "mediahandler-api-collection",
+    "description": "Full collection for MediaHandler API.\n\nAuthentication uses the DevAuth handler (Development only).\nSet `X-Dev-IsAdmin` to `false` on individual requests to test non-admin access.\n\nVariables automatically captured by test scripts:\n- `mediaId` — set by POST /media or POST /tmdb/import\n- `wishlistId` — set by POST /wishlist\n- `userId` — set by GET /admin/users",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl",   "value": "http://localhost:5000", "type": "string" },
+    { "key": "mediaId",   "value": "", "type": "string" },
+    { "key": "seasonId",  "value": "", "type": "string" },
+    { "key": "episodeId", "value": "", "type": "string" },
+    { "key": "wishlistId","value": "", "type": "string" },
+    { "key": "userId",    "value": "", "type": "string" }
+  ],
+  "auth": {
+    "type": "noauth"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "GET Health",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/health", "host": ["{{baseUrl}}"], "path": ["api","v1","health"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "POST Sync User",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/sync", "host": ["{{baseUrl}}"], "path": ["api","v1","auth","sync"] }
+          }
+        },
+        {
+          "name": "GET Me",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/me", "host": ["{{baseUrl}}"], "path": ["api","v1","auth","me"] }
+          }
+        },
+        {
+          "name": "PUT Update Preferences",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"preferredLanguage\": \"fr\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/preferences", "host": ["{{baseUrl}}"], "path": ["api","v1","auth","preferences"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Media",
+      "item": [
+        {
+          "name": "GET Media Stats",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/media/stats", "host": ["{{baseUrl}}"], "path": ["api","v1","media","stats"] }
+          }
+        },
+        {
+          "name": "GET Media List",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/media?page=1&pageSize=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","media"],
+              "query": [
+                { "key": "page",     "value": "1" },
+                { "key": "pageSize", "value": "20" },
+                { "key": "search",   "value": "", "disabled": true },
+                { "key": "type",     "value": "Movie", "disabled": true },
+                { "key": "isWatched","value": "false", "disabled": true },
+                { "key": "genre",    "value": "Action", "disabled": true }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET Media by ID",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/media/{{mediaId}}", "host": ["{{baseUrl}}"], "path": ["api","v1","media","{{mediaId}}"] }
+          }
+        },
+        {
+          "name": "POST Create Media",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.collectionVariables.set('mediaId', body.data.id);",
+                  "    console.log('mediaId set to', body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tmdbId\": 550,\n  \"title\": \"Fight Club\",\n  \"originalTitle\": \"Fight Club\",\n  \"overview\": \"An insomniac office worker forms an underground fight club.\",\n  \"type\": \"Movie\",\n  \"releaseDate\": \"1999-10-15T00:00:00Z\",\n  \"runtime\": 139,\n  \"posterPath\": \"/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg\",\n  \"backdropPath\": \"/hZkgoQYus5vegHoetLkCJzVSiL2.jpg\",\n  \"voteAverage\": 8.4,\n  \"voteCount\": 26280,\n  \"genres\": [\"Drama\", \"Thriller\"],\n  \"language\": \"en\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/media", "host": ["{{baseUrl}}"], "path": ["api","v1","media"] }
+          }
+        },
+        {
+          "name": "PUT Set Media Watched",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"isWatched\": true\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/media/{{mediaId}}/watched", "host": ["{{baseUrl}}"], "path": ["api","v1","media","{{mediaId}}","watched"] }
+          }
+        },
+        {
+          "name": "DELETE Media (Admin)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/media/{{mediaId}}", "host": ["{{baseUrl}}"], "path": ["api","v1","media","{{mediaId}}"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Episodes",
+      "item": [
+        {
+          "name": "GET Seasons",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/media/{{mediaId}}/seasons", "host": ["{{baseUrl}}"], "path": ["api","v1","media","{{mediaId}}","seasons"] }
+          }
+        },
+        {
+          "name": "PUT Set Episode Watched",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"isWatched\": true\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/media/{{mediaId}}/seasons/{{seasonId}}/episodes/{{episodeId}}/watched", "host": ["{{baseUrl}}"], "path": ["api","v1","media","{{mediaId}}","seasons","{{seasonId}}","episodes","{{episodeId}}","watched"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "TMDB",
+      "item": [
+        {
+          "name": "GET Search TMDB",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/tmdb/search?query=Breaking+Bad",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","tmdb","search"],
+              "query": [
+                { "key": "query",    "value": "Breaking Bad" },
+                { "key": "language", "value": "en", "disabled": true }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST Import from TMDB",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    pm.collectionVariables.set('mediaId', body.data.id);",
+                  "    console.log('mediaId set to', body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/tmdb/import/550?mediaType=Movie&language=en",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","tmdb","import","550"],
+              "query": [
+                { "key": "mediaType", "value": "Movie" },
+                { "key": "language",  "value": "en", "disabled": true }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Wishlist",
+      "item": [
+        {
+          "name": "GET Wishlist",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/wishlist?page=1&pageSize=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","wishlist"],
+              "query": [
+                { "key": "page",     "value": "1" },
+                { "key": "pageSize", "value": "20" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST Add to Wishlist",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const body = pm.response.json();",
+                  "    pm.collectionVariables.set('wishlistId', body.data.id);",
+                  "    console.log('wishlistId set to', body.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tmdbId\": 238,\n  \"title\": \"The Godfather\",\n  \"posterPath\": \"/3bhkrj58Vtu7enYsLegHnDmRWTh.jpg\",\n  \"releaseDate\": \"1972-03-24T00:00:00Z\",\n  \"notes\": \"Must watch classic\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/wishlist", "host": ["{{baseUrl}}"], "path": ["api","v1","wishlist"] }
+          }
+        },
+        {
+          "name": "PUT Mark Wishlist Acquired",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"isAcquired\": true\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/wishlist/{{wishlistId}}/acquired", "host": ["{{baseUrl}}"], "path": ["api","v1","wishlist","{{wishlistId}}","acquired"] }
+          }
+        },
+        {
+          "name": "DELETE Remove from Wishlist",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": { "raw": "{{baseUrl}}/api/v1/wishlist/{{wishlistId}}", "host": ["{{baseUrl}}"], "path": ["api","v1","wishlist","{{wishlistId}}"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Files",
+      "item": [
+        {
+          "name": "POST Scan NAS (Admin)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/files/scan",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","files","scan"],
+              "query": [
+                { "key": "basePath", "value": "/movies", "disabled": true }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin",
+      "item": [
+        {
+          "name": "GET Users",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const body = pm.response.json();",
+                  "    if (body.data && body.data.length > 0) {",
+                  "        pm.collectionVariables.set('userId', body.data[0].id);",
+                  "        console.log('userId set to', body.data[0].id);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/admin/users?page=1&pageSize=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["api","v1","admin","users"],
+              "query": [
+                { "key": "page",     "value": "1" },
+                { "key": "pageSize", "value": "20" },
+                { "key": "search",   "value": "", "disabled": true }
+              ]
+            }
+          }
+        },
+        {
+          "name": "PUT Set User Role",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"role\": \"User\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{userId}}/role", "host": ["{{baseUrl}}"], "path": ["api","v1","admin","users","{{userId}}","role"] }
+          }
+        },
+        {
+          "name": "PUT Set User Active",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-Dev-OktaId",  "value": "okta|devuser1" },
+              { "key": "X-Dev-Email",   "value": "dev@local.com" },
+              { "key": "X-Dev-IsAdmin", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"isActive\": true\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{userId}}/active", "host": ["{{baseUrl}}"], "path": ["api","v1","admin","users","{{userId}}","active"] }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Clean Architecture with .NET 10:
 - **FluentValidation 11** — request validation
 - **AutoMapper 12** — entity → DTO mapping
 - **Serilog** — structured logging (console + rolling file)
-- **Okta OAuth 2.0** — JWT authentication
+- **Auth0 OAuth 2.0** — JWT authentication
 - **TMDB API** — media metadata
 - **Freebox API** — NAS file system access via local Freebox router
 - **Microsoft.Extensions.Http.Resilience** — HTTP client resilience (standard retry + circuit-breaker)
@@ -73,7 +73,7 @@ Clean Architecture with .NET 10:
 ### ✅ Phase 5 — API Layer
 - Serilog configured with bootstrap logger, rolling file + console sinks, machine/environment enrichers
 - Swagger / OpenAPI with JWT Bearer security definition and `[ProducesResponseType]` on all actions
-- Okta JWT authentication (`AddApiAuthentication`)
+- Auth0 JWT authentication (`AddApiAuthentication`)
 - `AdminOnly` policy for admin-restricted endpoints
 - Fixed-window rate limiting — 100 req/min
 - Global exception handler (`GlobalExceptionHandler`) — structured `ApiResponse` for all errors
@@ -166,7 +166,7 @@ MediaHandler.API/
 |--------|-------|-------------|------|
 | `GET` | `/health` | Health check (DB ping) | Public |
 | `GET` | `/api/v1/health` | Health check with status response | Public |
-| `POST` | `/api/v1/auth/sync` | Sync Okta user to local DB on login | User |
+| `POST` | `/api/v1/auth/sync` | Sync Auth0 user to local DB on login | User |
 | `GET` | `/api/v1/auth/me` | Current user profile | User |
 | `PUT` | `/api/v1/auth/preferences` | Update language preference | User |
 | `GET` | `/api/v1/media` | List media (page, search, type, genre, watched) | User |
@@ -197,7 +197,7 @@ MediaHandler.API/
 ### User Secrets — Development Setup
 
 ```bash
-dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.okta.com" --project MediaHandler.API
+dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.eu.auth0.com/" --project MediaHandler.API
 dotnet user-secrets set "Okta:ClientId"      "your-client-id"             --project MediaHandler.API
 dotnet user-secrets set "Okta:ClientSecret"  "your-client-secret"         --project MediaHandler.API
 dotnet user-secrets set "Tmdb:ApiKey"        "your-tmdb-api-key"          --project MediaHandler.API
@@ -210,7 +210,7 @@ dotnet user-secrets set "Nas:BasePaths:1"    "/Disk/Media/Series"         --proj
 ### Environment Variables — Production
 
 ```sh
-OKTA__DOMAIN=https://dev-xxxxx.okta.com
+OKTA__DOMAIN=https://dev-xxxxx.eu.auth0.com/
 OKTA__CLIENTSECRET=your-secret
 TMDB__APIKEY=your-key
 NAS__APPID=mediahandler
@@ -234,7 +234,7 @@ The `AppToken` is a one-time token granted by Freebox OS. To obtain it:
 ### Prerequisites
 - .NET 10 SDK
 - SQL Server / SQL Server LocalDB
-- Okta Developer account
+- Auth0 account (with API and Application configured)
 - TMDB API key
 - Freebox router at `http://mafreebox.freebox.fr`
 
@@ -304,7 +304,7 @@ Private project for personal use.
 - [x] `MediaHandlerDbContext` with all `DbSet<T>` properties
 - [x] Fluent API entity configurations for all 8 entities (unique indexes, constraints, relations)
 - [x] EF Core migration: `InitialCreate`
-- [x] `CurrentUserService` resolving user identity from Okta JWT claims
+- [x] `CurrentUserService` resolving user identity from Auth0 JWT claims
 - [x] Strongly-typed options: `OktaOptions`, `TmdbOptions`, `NasOptions`
 - [x] **`FreeboxNasService`**: Full Freebox API integration
   - HMAC-SHA1 session authentication against local Freebox router
@@ -317,7 +317,7 @@ Private project for personal use.
 - [x] `HealthController` — `GET /api/v1/health`
 - [x] Swagger / OpenAPI with JWT Bearer security definition
 - [x] CORS configured
-- [x] Okta JWT authentication middleware (`AddApiAuthentication`)
+- [x] Auth0 JWT authentication middleware (`AddApiAuthentication`)
 - [x] Global exception handler middleware (`GlobalExceptionHandler`)
 - [x] Rate limiting — fixed window, 100 req/min (`AddApiRateLimiting`)
 
@@ -388,7 +388,7 @@ MediaHandler.API/
 
 ```bash
 # Okta
-dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.okta.com" --project MediaHandler.API
+dotnet user-secrets set "Okta:Domain"        "https://dev-xxxxx.eu.auth0.com/" --project MediaHandler.API
 dotnet user-secrets set "Okta:ClientId"      "your-client-id"             --project MediaHandler.API
 dotnet user-secrets set "Okta:ClientSecret"  "your-client-secret"         --project MediaHandler.API
 
@@ -405,7 +405,7 @@ dotnet user-secrets set "Nas:BasePaths:1"    "/Disk/Media/Series"         --proj
 ### Environment Variables — Production
 
 ```sh
-OKTA__DOMAIN=https://dev-xxxxx.okta.com
+OKTA__DOMAIN=https://dev-xxxxx.eu.auth0.com/
 OKTA__CLIENTSECRET=your-secret
 TMDB__APIKEY=your-key
 NAS__APPID=mediahandler
@@ -429,7 +429,7 @@ The `AppToken` is a one-time token granted by the Freebox OS UI. To obtain it:
 ### Prerequisites
 - .NET 10 SDK
 - SQL Server / SQL Server LocalDB
-- Okta Developer account
+- Auth0 account (with API and Application configured)
 - TMDB API key
 - Freebox router accessible at `http://mafreebox.freebox.fr`
 
@@ -455,7 +455,7 @@ dotnet ef database update --project MediaHandler.Infrastructure --startup-projec
 | Status | Method | Route | Description | Auth |
 |--------|--------|-------|-------------|------|
 | ✅ | `GET` | `/api/v1/health` | Health check | Public |
-| ✅ | `POST` | `/api/v1/auth/sync` | Sync Okta user on login | User |
+| ✅ | `POST` | `/api/v1/auth/sync` | Sync Auth0 user on login | User |
 | ✅ | `GET` | `/api/v1/auth/me` | Current user profile | User |
 | ✅ | `PUT` | `/api/v1/auth/preferences` | Update language preference | User |
 | ✅ | `GET` | `/api/v1/media` | List media (page, search, type, watched filter) | User |
@@ -495,7 +495,7 @@ Private project for personal use.
 Clean Architecture with .NET 10:
 - **Domain Layer**: Entities, enums, interfaces, exceptions (no dependencies)
 - **Application Layer**: CQRS with MediatR, business logic, DTOs
-- **Infrastructure Layer**: EF Core, external services (TMDB, NAS, Okta)
+- **Infrastructure Layer**: EF Core, external services (TMDB, NAS, Auth0)
 - **API Layer**: ASP.NET Core Web API controllers
 
 ## Technology Stack
@@ -505,7 +505,7 @@ Clean Architecture with .NET 10:
 - **Entity Framework Core 10** - ORM with SQL Server
 - **MediatR** - CQRS pattern implementation
 - **FluentValidation** - Request validation
-- **Okta OAuth 2.0** - Authentication (to be configured)
+- **Auth0 OAuth 2.0** - Authentication (configured)
 - **TMDB API** - Media metadata (to be configured)
 
 ## Features


### PR DESCRIPTION
This pull request migrates the authentication provider from Okta to Auth0 throughout the MediaHandler project, updates the JWT authentication and claim handling, and removes legacy Okta-specific code. It also improves database initialization and expands allowed origins for development. The most important changes are grouped below.

**Authentication Provider Migration:**

* Switched from Okta to Auth0 for JWT authentication, updating all references, documentation, and configuration files (e.g., `README.md`, user secrets, environment variables, and API documentation). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L169-R169) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L200-R200) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R213) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L237-R237) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L307-R307) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L320-R320) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L391-R391) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L408-R408) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L432-R432) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L458-R458) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L498-R498) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L508-R508)
* Updated JWT authentication setup in `AddApiAuthentication` to ensure correct OIDC discovery for Auth0, and set the custom role claim type to match Auth0's namespace.
* Changed Swagger/OpenAPI security description to reference Auth0 instead of Okta.
* Changed default development user ID prefix in `DevAuthenticationHandler` from Okta to Auth0.

**JWT Claim Handling and User Service Refactor:**

* Refactored `CurrentUserService` and its interface to remove the obsolete `UserId` property, rely on `OktaId` (now Auth0 subject claim), and use Auth0's role claim for admin checks. [[1]](diffhunk://#diff-1831d7d4a2b73d6821ff128bb656bec2ced13b5ea71f6dd5f1a8e8868c6b15a3R9-R14) [[2]](diffhunk://#diff-3bef328612809c5b3b31ec9e0e63041e61891c5e776402135d21a6cb6139e4f4L5)
* Updated query handlers (`GetMediaByIdQueryHandler` and `GetMediaStatsQueryHandler`) to resolve the user's database ID from the Auth0 subject claim, instead of directly using a GUID from JWT. [[1]](diffhunk://#diff-f543910d837e69606f67d653470c7df742307580e42ddd23786998f297981e34L16-R21) [[2]](diffhunk://#diff-0ffff60cc73b8b2258719953b2545e55dafe8e7796ac44cf12898477bc13cebcL24-R30)
* Updated integration tests to remove the `UserId` dependency and use the Auth0 subject claim.

**Infrastructure Cleanup:**

* Removed legacy Okta-specific identity files from the infrastructure project, cleaning up the project file. [[1]](diffhunk://#diff-4728197d59bc8bf002b56b82cf579657a7c1af6a8e3ca46ca31c23e860f77bf0R3-R8) [[2]](diffhunk://#diff-4728197d59bc8bf002b56b82cf579657a7c1af6a8e3ca46ca31c23e860f77bf0L20-L23)

**Database Initialization Improvement:**

* Improved database initialization to check connectivity and apply migrations only if needed, reducing startup errors for new deployments.

**Development Environment Update:**

* Expanded allowed origins in `appsettings.json` to include Angular development (`http://localhost:4200`).