### PR TITLE
fix(nas): decode Freebox Base64 paths, recursive scan, video-only fil…

### DIFF
--- a/MediaHandler.Application/Common/MediaFileConstants.cs
+++ b/MediaHandler.Application/Common/MediaFileConstants.cs
@@ -1,0 +1,26 @@
+namespace MediaHandler.Application.Common;
+
+/// <summary>
+/// Shared constants for media file handling, used across Application and Infrastructure layers.
+/// </summary>
+public static class MediaFileConstants
+{
+    /// <summary>
+    /// The set of video file extensions that are recognised as importable media files.
+    /// Comparison is case-insensitive.
+    /// </summary>
+    public static readonly HashSet<string> VideoExtensions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".m4v",
+            ".flv", ".ts", ".m2ts", ".mpg", ".mpeg", ".webm"
+        };
+
+    /// <summary>
+    /// Returns <c>true</c> when the file at <paramref name="filePath"/> has a recognised
+    /// video extension; <c>false</c> otherwise.
+    /// </summary>
+    public static bool IsVideoFile(string filePath) =>
+        VideoExtensions.Contains(Path.GetExtension(filePath));
+}
+

--- a/MediaHandler.Application/Features/Files/Commands/ScanAndImportNas/ScanAndImportNasCommandHandler.cs
+++ b/MediaHandler.Application/Features/Files/Commands/ScanAndImportNas/ScanAndImportNasCommandHandler.cs
@@ -1,3 +1,4 @@
+using MediaHandler.Application.Common;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Application.Common.Models;
 using MediaHandler.Domain.Entities;
@@ -32,11 +33,22 @@ public class ScanAndImportNasCommandHandler(
 
         var entries = (await nasService.ScanDirectoryAsync(request.BasePath, cancellationToken)).ToList();
 
-        var files = entries.Where(e => !e.IsDirectory).ToList();
         var foldersFound = entries.Count(e => e.IsDirectory);
+        var allFiles = entries.Where(e => !e.IsDirectory).ToList();
+
+        // Only retain recognized video files — skip system files, PDFs, executables, etc.
+        var files = allFiles
+            .Where(e => MediaFileConstants.IsVideoFile(e.FileName))
+            .ToList();
+
+        var skippedNonMedia = allFiles.Count - files.Count;
+        if (skippedNonMedia > 0)
+            logger.LogInformation(
+                "Ignored {SkippedNonMedia} non-video file(s) returned by the NAS scan.",
+                skippedNonMedia);
 
         logger.LogInformation(
-            "NAS scan complete. Files={FileCount}, Folders={FolderCount}.",
+            "NAS scan complete. VideoFiles={FileCount}, Folders={FolderCount}.",
             files.Count, foldersFound);
 
         // 2. Dedup by FilePath — only add genuinely new files

--- a/MediaHandler.Infrastructure/Nas/FreeboxNasService.cs
+++ b/MediaHandler.Infrastructure/Nas/FreeboxNasService.cs
@@ -140,8 +140,13 @@ public sealed class FreeboxNasService(
         var extension = Path.GetExtension(entry.Name).TrimStart('.').ToUpperInvariant();
         var isDirectory = entry.Type == "dir";
 
+        // The Freebox API returns 'path' as a Base64-encoded UTF-8 string.
+        // Decode it so that FilePath is always a human-readable plain-text path,
+        // which can be safely re-encoded by EncodePath() for subsequent API calls.
+        var plainPath = DecodeFreeboxPath(entry.Path);
+
         return new NasFileInfo(
-            FilePath: entry.Path,
+            FilePath: plainPath,
             FileName: entry.Name,
             SizeBytes: entry.Size ?? 0,
             Format: isDirectory || string.IsNullOrEmpty(extension) ? null : extension,
@@ -150,8 +155,37 @@ public sealed class FreeboxNasService(
             IsDirectory: isDirectory);
     }
 
-    private async Task<IEnumerable<NasFileInfo>> ScanSinglePathAsync(string path, CancellationToken cancellationToken)
+    /// <summary>
+    /// Decodes a Freebox path from its Base64 representation to a plain-text UTF-8 string.
+    /// Falls back to returning the input unchanged if it is not valid Base64.
+    /// </summary>
+    private static string DecodeFreeboxPath(string encodedPath)
     {
+        try
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(encodedPath));
+        }
+        catch
+        {
+            // Already plain text (e.g., in unit tests or future API versions)
+            return encodedPath;
+        }
+    }
+
+    private async Task<IEnumerable<NasFileInfo>> ScanSinglePathAsync(
+        string path,
+        CancellationToken cancellationToken,
+        int depth = 0)
+    {
+        const int maxDepth = 10;
+
+        if (depth > maxDepth)
+        {
+            logger.LogWarning(
+                "Maximum scan depth ({MaxDepth}) reached at '{Path}'. Stopping recursion.", maxDepth, path);
+            return [];
+        }
+
         var response = await GetFreeboxAsync<FreeboxResponse<List<FreeboxFileEntry>>>(
             $"/api/{_options.ApiVersion}/fs/ls/{EncodePath(path)}", cancellationToken);
 
@@ -161,8 +195,18 @@ public sealed class FreeboxNasService(
             return [];
         }
 
-        // Return both files AND directories so the handler can count them separately
-        return response.Result.Select(MapToNasFileInfo);
+        var entries = response.Result.Select(MapToNasFileInfo).ToList();
+        var result = new List<NasFileInfo>(entries);
+
+        // Recurse into visible subdirectories (skip hidden dirs like .Recycle_Bin, .Spotlight-V100)
+        foreach (var dir in entries.Where(e => e.IsDirectory && !e.FileName.StartsWith('.')))
+        {
+            logger.LogDebug("Recursing into subdirectory '{DirPath}' (depth={Depth}).", dir.FilePath, depth + 1);
+            var subEntries = await ScanSinglePathAsync(dir.FilePath, cancellationToken, depth + 1);
+            result.AddRange(subEntries);
+        }
+
+        return result;
     }
 
     private record FreeboxResponse<T>(

--- a/MediaHandler.Infrastructure/Nas/MediaFileNameParser.cs
+++ b/MediaHandler.Infrastructure/Nas/MediaFileNameParser.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using MediaHandler.Application.Common;
 using MediaHandler.Application.Common.DTOs;
 using MediaHandler.Application.Common.Interfaces;
 
@@ -19,13 +20,8 @@ namespace MediaHandler.Infrastructure.Nas;
 /// </remarks>
 public sealed class MediaFileNameParser : IMediaFileNameParser
 {
-    // Video file extensions we recognise as media
-    private static readonly HashSet<string> VideoExtensions =
-        new(StringComparer.OrdinalIgnoreCase)
-        {
-            ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".m4v",
-            ".flv", ".ts", ".m2ts", ".mpg", ".mpeg", ".webm"
-        };
+    // Video file extensions we recognize as media — single source of truth in MediaFileConstants
+    private static readonly HashSet<string> VideoExtensions = MediaFileConstants.VideoExtensions;
 
     // Path segments that indicate a movie folder
     private static readonly string[] MovieSegments =
@@ -33,7 +29,7 @@ public sealed class MediaFileNameParser : IMediaFileNameParser
 
     // Path segments that indicate a TV show folder
     private static readonly string[] TvSegments =
-        ["series", "tv", "tv shows", "tvshows", "shows", "anime"];
+        ["series", "séries", "tv", "tv shows", "tvshows", "shows", "anime"];
 
     // Strips quality/codec/source tags and everything after them
     // e.g., "The Matrix 1999 1080p BluRay x264" → "The Matrix 1999"

--- a/MediaHandler.Infrastructure/Services/MediaAutoMatchService.cs
+++ b/MediaHandler.Infrastructure/Services/MediaAutoMatchService.cs
@@ -1,3 +1,4 @@
+using MediaHandler.Application.Common;
 using MediaHandler.Application.Common.DTOs;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Domain.Entities;
@@ -7,10 +8,20 @@ namespace MediaHandler.Infrastructure.Services;
 
 /// <summary>
 /// Infrastructure implementation of <see cref="IMediaAutoMatchService"/>.
+/// <para>
 /// Iterates over unlinked <see cref="MediaFile"/> records, parses each filename,
 /// queries TMDB, imports (or retrieves) the matching <c>Media</c> entity, and sets
 /// <c>MediaFile.MediaId</c>. Changes are flushed to the database in batches of 10.
-/// A 250 ms delay is introduced between TMDB API calls to respect the rate limit.
+/// </para>
+/// <para>
+/// TMDB rate limit: 40 requests per 10 seconds (4 req/s). A <see cref="TmdbDelayMs"/>
+/// delay is applied after every TMDB HTTP call to stay within this limit.
+/// An in-memory title cache prevents duplicate TMDB round-trips for TV shows
+/// that have many episode files sharing the same title (e.g., 20 episodes of one
+/// series only trigger 1 TMDB search + 1 details call instead of 20).
+/// The Polly <c>StandardResilienceHandler</c> on the TMDB HttpClient handles any
+/// HTTP 429 responses automatically with exponential back-off.
+/// </para>
 /// </summary>
 public sealed class MediaAutoMatchService(
     IMediaFileNameParser parser,
@@ -21,7 +32,14 @@ public sealed class MediaAutoMatchService(
     : IMediaAutoMatchService
 {
     private const int BatchSize = 10;
-    private const int TmdbDelayMs = 250;
+
+    /// <summary>
+    /// Delay in milliseconds applied after every TMDB API call.
+    /// TMDB allows 40 req/10 s (~4 req/s → 250 ms minimum spacing).
+    /// Using 300 ms gives a comfortable margin when two calls are made
+    /// per file (search + details).
+    /// </summary>
+    private const int TmdbDelayMs = 300;
 
     /// <inheritdoc/>
     public async Task<AutoMatchResult> MatchAndLinkUnlinkedFilesAsync(
@@ -33,19 +51,35 @@ public sealed class MediaAutoMatchService(
         var errors = new List<string>();
         var processedSinceSave = 0;
 
+        // In-memory caches for the current batch.
+        // Avoids duplicate TMDB round-trips when multiple files share the same
+        // show/movie title (very common for TV series with many episodes).
+        var resolvedCache = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+        var noResultCache = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         logger.LogInformation(
             "Starting auto-match for {Count} unlinked MediaFile(s).", unlinkedFiles.Count);
 
-        for (var i = 0; i < unlinkedFiles.Count; i++)
+        foreach (var file in unlinkedFiles)
         {
-            var file = unlinkedFiles[i];
-
             try
             {
                 // 1. Parse filename
                 var parsed = parser.Parse(file.FilePath);
                 if (parsed is null)
                 {
+                    // Non-video files that slipped into the MediaFiles table are silently
+                    // skipped — they are not failures.
+                    if (!MediaFileConstants.IsVideoFile(file.FilePath))
+                    {
+                        logger.LogDebug(
+                            "Skipping non-video MediaFile {FileId} ('{FilePath}').",
+                            file.Id, file.FilePath);
+                        skipped++;
+                        processedSinceSave++;
+                        continue;
+                    }
+
                     logger.LogWarning(
                         "Could not parse filename for MediaFile {FileId} ('{FilePath}'). Counting as failed.",
                         file.Id, file.FilePath);
@@ -54,18 +88,44 @@ public sealed class MediaAutoMatchService(
                     continue;
                 }
 
-                // 2. Search TMDB — append year when available for accuracy, fall back without it
+                // Build a cache key: "Title|Year" (Year=0 when unknown)
+                var cacheKey = $"{parsed.Title.ToLowerInvariant()}|{parsed.Year ?? 0}";
+
+                // 2a. Cache hit — already matched earlier in this batch
+                if (resolvedCache.TryGetValue(cacheKey, out var cachedMediaId))
+                {
+                    file.MediaId = cachedMediaId;
+                    matched++;
+                    processedSinceSave++;
+                    logger.LogInformation(
+                        "Linked MediaFile {FileId} → Media {MediaId} ('{Title}') [cache hit].",
+                        file.Id, cachedMediaId, parsed.Title);
+                    continue;
+                }
+
+                // 2b. Cache hit — already had no TMDB result earlier in this batch
+                if (noResultCache.Contains(cacheKey))
+                {
+                    logger.LogDebug(
+                        "Skipping MediaFile {FileId} ('{Title}'): no TMDB match found earlier in this batch.",
+                        file.Id, parsed.Title);
+                    skipped++;
+                    processedSinceSave++;
+                    continue;
+                }
+
+                // 3. Search TMDB — append year for accuracy, fall back without it
                 var query = parsed.Year.HasValue
                     ? $"{parsed.Title} {parsed.Year}"
                     : parsed.Title;
 
                 var searchResult = await tmdb.SearchMediaAsync(query, language, ct);
+                await Task.Delay(TmdbDelayMs, ct); // respect rate limit after every call
 
                 if (searchResult is null && parsed.Year.HasValue)
                 {
                     logger.LogInformation(
-                        "TMDB search with year found nothing for '{Query}'. Retrying without year.",
-                        query);
+                        "TMDB search with year found nothing for '{Query}'. Retrying without year.", query);
                     searchResult = await tmdb.SearchMediaAsync(parsed.Title, language, ct);
                     await Task.Delay(TmdbDelayMs, ct);
                 }
@@ -75,17 +135,21 @@ public sealed class MediaAutoMatchService(
                     logger.LogInformation(
                         "No TMDB result for '{Title}' (MediaFile {FileId}). Skipping.",
                         parsed.Title, file.Id);
+                    noResultCache.Add(cacheKey);
                     skipped++;
                     processedSinceSave++;
                     continue;
                 }
 
-                // 3. Determine media type — prefer hint from parser, fall back to TMDB result
+                // 4. Determine media type — prefer hint from parser, fall back to TMDB result
                 var mediaType = parsed.MediaTypeHint ?? searchResult.MediaType;
 
-                // 4. Import or retrieve existing Media entity
+                // 5. Import or retrieve existing Media entity
+                //    ImportOrGetExistingAsync checks the DB first; only calls TMDB when the
+                //    Media does not yet exist. The delay after the call accounts for that.
                 var importResult = await importer.ImportOrGetExistingAsync(
                     searchResult.Id, mediaType, language, ct);
+                await Task.Delay(TmdbDelayMs, ct); // delay covers the possible GetMediaDetails call
 
                 if (!importResult.IsSuccess)
                 {
@@ -98,8 +162,9 @@ public sealed class MediaAutoMatchService(
                     continue;
                 }
 
-                // 5. Link MediaFile → Media
+                // 6. Link MediaFile → Media and populate caches
                 file.MediaId = importResult.Value;
+                resolvedCache[cacheKey] = importResult.Value;
                 matched++;
                 processedSinceSave++;
 
@@ -123,10 +188,6 @@ public sealed class MediaAutoMatchService(
                 await context.SaveChangesAsync(ct);
                 processedSinceSave = 0;
             }
-
-            // Respect TMDB rate limit between calls
-            if (i < unlinkedFiles.Count - 1)
-                await Task.Delay(TmdbDelayMs, ct);
         }
 
         // Flush remaining changes


### PR DESCRIPTION
…ter, TMDB cache

Fixes #48 #49 #50 #51
## Root cause
The Freebox OS API returns entry.path as a Base64-encoded UTF-8 string. MapToNasFileInfo stored the raw Base64 value in NasFileInfo.FilePath causing three cascading bugs.
## Changes
### FreeboxNasService (fixes #48 + #49)
- Decode entry.Path from Base64 in MapToNasFileInfo so FilePath is always plain-text; add DecodeFreeboxPath() helper with fallback for non-Base64 input
- Make ScanSinglePathAsync recursive (depth-first, max depth 10) so scanning 'Disque NAS 1/Series' now descends into show/season sub-folders to find actual episode files
- Skip hidden directories (starting with '.') to avoid .Recycle_Bin etc. ### MediaFileConstants (fixes #50)
- New shared class in Application/Common with canonical VideoExtensions set (.mkv, .mp4, .avi, ...) and IsVideoFile() helper — single source of truth ### ScanAndImportNasCommandHandler (fixes #50)
- Filter NAS entries by video extension before inserting as MediaFile records; non-video files (pdf, exe, ico, inf) are logged and skipped ### MediaFileNameParser (fixes #50)
- Reference MediaFileConstants.VideoExtensions instead of duplicating the list ### MediaAutoMatchService (fixes #51)
- Add in-memory title cache (resolvedCache + noResultCache) keyed by 'title|year': TV series with N episodes now trigger 1 TMDB search + 1 details call instead of N; episodes 2..N are linked from cache (0 calls)
- Non-video MediaFile records in DB are silently skipped (Debug) not failed
- Move Task.Delay(300ms) to after each TMDB call (search AND import) instead of after each file iteration to correctly respect the 40 req/10s limit