### PR TITLE
fix(auth): improve user synchronization

### DIFF
--- a/MediaHandler.API/Contracts/Auth/SyncUserRequest.cs
+++ b/MediaHandler.API/Contracts/Auth/SyncUserRequest.cs
@@ -1,0 +1,18 @@
+namespace MediaHandler.API.Contracts.Auth;
+
+/// <summary>
+/// Optional body for POST auth/sync.
+/// The frontend sends user profile data sourced from the Auth0 ID token (auth0.user$),
+/// used as fallback when the access token does not contain those claims.
+///
+/// This handles two cases:
+///  - Auth0 access token without audience → opaque token (no JWT, no extractable claims).
+///  - Auth0 Action not configured → access token lacks email/name custom claims.
+///
+/// The Sub field is only trusted in development (DevAuthenticationHandler).
+/// In production the real JWT bearer validation always provides the authoritative sub.
+/// </summary>
+public record SyncUserRequest(
+    string? Sub,
+    string? Email,
+    string? Name);

--- a/MediaHandler.API/Controllers/AuthController.cs
+++ b/MediaHandler.API/Controllers/AuthController.cs
@@ -22,12 +22,37 @@ public class AuthController(ISender sender) : ControllerBase
     [ProducesResponseType<ApiResponse<UserDto>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> Sync(CancellationToken ct)
+    public async Task<IActionResult> Sync([FromBody] SyncUserRequest? body, CancellationToken ct)
     {
-        var oktaId = User.FindFirstValue("sub")!;
-        var email = User.FindFirstValue(ClaimTypes.Email) ?? User.FindFirstValue("email")!;
-        var name = User.FindFirstValue("name");
-        var isAdmin = User.IsInRole("Admin");
+        // JWT bearer (production) always provides the authoritative sub.
+        // In development with an opaque token (no audience configured), the sub is null
+        // so we fall back to the value sent by the frontend from the Auth0 ID token.
+        var oktaId = User.FindFirstValue("sub") ?? body?.Sub;
+        if (string.IsNullOrEmpty(oktaId))
+            return Unauthorized();
+
+        // Auth0 access tokens do NOT include email/name by default — those live in the
+        // ID token only. The frontend sends them in the request body (sourced from auth0.user$)
+        // as a reliable fallback. JWT claims always take priority when present (e.g. when an
+        // Auth0 Action explicitly adds them to the access token).
+        var email = User.FindFirstValue(ClaimTypes.Email)
+            ?? User.FindFirstValue("email")
+            ?? User.FindFirstValue("preferred_username")
+            ?? body?.Email;
+
+        if (string.IsNullOrEmpty(email))
+            return BadRequest(ApiResponse<object>.Fail(new ApiError("MISSING_CLAIM",
+                "Could not determine the user's email address from the token or request body.")));
+
+        // Display name: JWT claims first, then request body fallback
+        var name = User.FindFirstValue("name")
+            ?? User.FindFirstValue("given_name")
+            ?? body?.Name;
+
+        // Accept both "Admin" and "Administrator" as admin role names to be resilient
+        // to differences in how the role is named in the identity provider.
+        // RoleClaimType is configured to "https://mediahandler.com/roles" in JwtBearer options.
+        var isAdmin = User.IsInRole("Admin") || User.IsInRole("Administrator");
 
         var result = await sender.Send(new SyncUserCommand(oktaId, email, name, isAdmin), ct);
         return result.IsSuccess

--- a/MediaHandler.API/Identity/CurrentUserService.cs
+++ b/MediaHandler.API/Identity/CurrentUserService.cs
@@ -6,7 +6,11 @@ namespace MediaHandler.API.Identity;
 
 public class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService
 {
-    public string? Email => httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.Email);
+    // Auth0/Okta access tokens use the raw "email" claim, not the XML-schema form
+    // (ClaimTypes.Email = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress").
+    public string? Email =>
+        httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.Email)
+        ?? httpContextAccessor.HttpContext?.User?.FindFirstValue("email");
 
     public string? OktaId => httpContextAccessor.HttpContext?.User?.FindFirstValue("sub");
 

--- a/MediaHandler.API/Identity/DevAuthenticationHandler.cs
+++ b/MediaHandler.API/Identity/DevAuthenticationHandler.cs
@@ -1,17 +1,29 @@
 using System.Security.Claims;
+using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace MediaHandler.API.Identity;
 
 /// <summary>
-/// Development-only authentication handler. Authenticates every request automatically
-/// using headers so Swagger and tools work without a real Okta token.
+/// Development-only authentication handler.
 ///
-/// Headers (all optional — defaults apply when omitted):
-///   X-Dev-OktaId    — OktaId claim (default: "okta|devuser1")
-///   X-Dev-Email     — Email claim  (default: "dev@local.com")
+/// Priority order:
+///   1. Real Bearer JWT — if a valid JWT is present in the Authorization header, its
+///      claims (sub, email, name, roles) are extracted WITHOUT signature validation.
+///      This allows real Auth0 users to authenticate in development.
+///
+///   2. X-Dev-* headers — useful for Swagger, integration tests, or manual overrides
+///      when no real JWT is available.
+///
+///   3. Hardcoded defaults — "auth0|devuser1" / "dev@local.com" / Admin role.
+///      These are intentionally kept for unit tests that don't provide a token.
+///
+/// Headers (all optional, only used when no Bearer JWT is present):
+///   X-Dev-OktaId    — sub claim    (default: "auth0|devuser1")
+///   X-Dev-Email     — email claim  (default: "dev@local.com")
 ///   X-Dev-IsAdmin   — Pass "false" to remove the Admin role (default: admin = true)
 /// </summary>
 public class DevAuthenticationHandler(
@@ -21,8 +33,44 @@ public class DevAuthenticationHandler(
 {
     public const string SchemeName = "DevAuth";
 
+    /// <summary>
+    /// Namespaced roles claim — must match the API's RoleClaimType and the Auth0 Action.
+    /// </summary>
+    private const string RolesClaimName = "https://mediahandler.com/roles";
+
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        // 1. Try to extract claims from a real Bearer JWT (no signature validation in dev).
+        var authHeader = Request.Headers.Authorization.FirstOrDefault();
+        Logger.LogDebug("[DevAuth] Authorization header: {Header}",
+            authHeader is null ? "<absent>" : authHeader[..Math.Min(authHeader.Length, 40)] + "…");
+
+        if (authHeader?.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            var token = authHeader["Bearer ".Length..].Trim();
+            var parts = token.Split('.');
+            Logger.LogDebug("[DevAuth] Token parts count: {Count} (3 = JWT, other = opaque)", parts.Length);
+
+            var jwtClaims = TryExtractJwtClaims(token);
+            if (jwtClaims is not null)
+            {
+                var jwtSub = jwtClaims.FirstOrDefault(c => c.Type == "sub")?.Value;
+                var jwtEmail = jwtClaims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Email)?.Value;
+                Logger.LogInformation("[DevAuth] Real JWT detected → sub={Sub}, email={Email}", jwtSub, jwtEmail ?? "<absent>");
+
+                var jwtIdentity = new ClaimsIdentity(jwtClaims, SchemeName);
+                var jwtTicket = new AuthenticationTicket(new ClaimsPrincipal(jwtIdentity), SchemeName);
+                return Task.FromResult(AuthenticateResult.Success(jwtTicket));
+            }
+
+            Logger.LogWarning("[DevAuth] Token present but not a decodable JWT (likely opaque — check Auth0 API audience). Falling back to dev defaults.");
+        }
+        else
+        {
+            Logger.LogDebug("[DevAuth] No Bearer token → using dev defaults (Swagger / unit tests).");
+        }
+
+        // 2. Fall back to X-Dev-* headers, then hardcoded defaults (unit tests / Swagger).
         var oktaId = Request.Headers["X-Dev-OktaId"].FirstOrDefault() ?? "auth0|devuser1";
         var email = Request.Headers["X-Dev-Email"].FirstOrDefault() ?? "dev@local.com";
         var isAdmin = !string.Equals(
@@ -41,7 +89,72 @@ public class DevAuthenticationHandler(
 
         var identity = new ClaimsIdentity(claims, SchemeName);
         var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
-
         return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    /// <summary>
+    /// Decodes the JWT payload without validating the signature (dev-only).
+    /// Returns null if the token is not a well-formed JWT or has no subject claim.
+    /// </summary>
+    private static List<Claim>? TryExtractJwtClaims(string token)
+    {
+        try
+        {
+            var parts = token.Split('.');
+            if (parts.Length != 3)
+                return null;
+
+            // Base64Url → Base64 padding
+            var payload = parts[1];
+            payload = payload.Replace('-', '+').Replace('_', '/');
+            payload += (payload.Length % 4) switch
+            {
+                2 => "==",
+                3 => "=",
+                _ => string.Empty,
+            };
+
+            var bytes = Convert.FromBase64String(payload);
+            using var doc = JsonDocument.Parse(Encoding.UTF8.GetString(bytes));
+            var root = doc.RootElement;
+
+            // sub is mandatory — it is the user's unique identity
+            if (!root.TryGetProperty("sub", out var subProp) ||
+                string.IsNullOrEmpty(subProp.GetString()))
+                return null;
+
+            var claims = new List<Claim>
+            {
+                new("sub", subProp.GetString()!),
+            };
+
+            // email
+            if (root.TryGetProperty("email", out var emailProp) &&
+                emailProp.GetString() is { Length: > 0 } email)
+                claims.Add(new(ClaimTypes.Email, email));
+
+            // name / display name
+            if (root.TryGetProperty("name", out var nameProp) &&
+                nameProp.GetString() is { Length: > 0 } name)
+                claims.Add(new("name", name));
+
+            // Roles from the namespaced custom claim (set by Auth0 Action)
+            if (root.TryGetProperty(RolesClaimName, out var rolesProp) &&
+                rolesProp.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var role in rolesProp.EnumerateArray())
+                {
+                    if (role.GetString() is { Length: > 0 } roleName)
+                        claims.Add(new(ClaimTypes.Role, roleName));
+                }
+            }
+
+            return claims;
+        }
+        catch
+        {
+            // Malformed token — fall back to dev defaults
+            return null;
+        }
     }
 }

--- a/MediaHandler.API/appsettings.json
+++ b/MediaHandler.API/appsettings.json
@@ -25,7 +25,7 @@
     "Domain": "",
     "ClientId": "",
     "ClientSecret": "",
-    "Audience": "api://mediahandler"
+    "Audience": ""
   },
   "Tmdb": {
     "BaseUrl": "https://api.themoviedb.org/3",


### PR DESCRIPTION
This pull request improves authentication handling in development and production environments by making the system more robust to differences in JWT claims and identity provider configurations. The main changes include enhanced claim extraction logic, improved fallback mechanisms for missing claims, and a more flexible development authentication handler that can process both real JWTs and development headers.

**Authentication robustness and flexibility:**

* The `AuthController.Sync` endpoint now accepts a `SyncUserRequest` body and uses a more robust approach to extract user claims, falling back to values from the request body if JWT claims are missing (e.g., in development or with opaque tokens). It also improves admin role detection and error handling for missing email claims.
* The `CurrentUserService.Email` property now checks both the standard `ClaimTypes.Email` and the raw `"email"` claim, increasing compatibility with different token formats.

**Development authentication improvements:**

* The `DevAuthenticationHandler` is refactored to first attempt extracting claims from a real Bearer JWT (without signature validation), then fall back to custom `X-Dev-*` headers, and finally to hardcoded defaults. This allows seamless switching between real tokens and development/test scenarios.
* Added a helper method to decode JWT payloads and extract claims (sub, email, name, roles) without signature validation, improving the fidelity of local authentication to production behavior.
* Updated documentation and comments in `DevAuthenticationHandler` to clarify the authentication priority order and the purpose of each step.

**Configuration:**

* The Auth0 `Audience` setting in `appsettings.json` is set to an empty string, likely to facilitate development with opaque tokens or to avoid misconfiguration during local testing.