### PR TITLE
Enhance title parsing and database compatibility for scanner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/002-admin-api-gaps/plan.md
+at specs/003-fix-scanner-title-parsing/plan.md
 <!-- SPECKIT END -->
 
 ## Active Technologies

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-admin-api-gaps"
+  "feature_directory": "specs/003-fix-scanner-title-parsing"
 }

--- a/MediaHandler.API/Program.cs
+++ b/MediaHandler.API/Program.cs
@@ -21,7 +21,11 @@ try
         .WriteTo.Console()
         .WriteTo.File("logs/mediahandler-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
 
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddHttpContextAccessor();
     builder.Services.AddExceptionHandler<GlobalExceptionHandler>();

--- a/MediaHandler.API/appsettings.json
+++ b/MediaHandler.API/appsettings.json
@@ -41,5 +41,12 @@
     "AppId": "mediahandler",
     "AppToken": "",
     "ApiVersion": "v8"
+  },
+  "Scanner": {
+    "ReleaseTags": {
+      "AdditionalPatterns": [],
+      "DisableDefaults": false
+    },
+    "DefaultSearchLanguages": [ "en-US" ]
   }
 }

--- a/MediaHandler.Application/Common/Models/Scanner/NameParserModels.cs
+++ b/MediaHandler.Application/Common/Models/Scanner/NameParserModels.cs
@@ -27,8 +27,19 @@ public record EpisodeNumberingHint(int? SeasonFromFolder = null);
 ///     Result of <c>IKodiNameParser.ParseEpisode</c>.
 ///     Contains one or more <see cref="EpisodeNumber" /> for multi-episode files.
 /// </summary>
+/// <param name="EpisodeTitle">
+///     The episode-specific title extracted from text <em>after</em> the SxxExx marker, if present.
+///     Distinct from <see cref="TmdbMatchModels.MatchQuery.Title" />, which carries the <em>show</em> title.
+/// </param>
+/// <param name="FolderTitle">
+///     The show title inferred by walking the folder hierarchy upward from the file,
+///     skipping season-level and TV-root folders. Used as a fallback / validation signal
+///     when the filename-derived title is unreliable.
+/// </param>
 public record EpisodeNameParseResult(
     bool IsSuccess,
     string? Title,
     IReadOnlyList<EpisodeNumber> EpisodeNumbers,
-    string? Warning = null);
+    string? Warning = null,
+    string? EpisodeTitle = null,
+    string? FolderTitle = null);

--- a/MediaHandler.Application/Common/Models/Scanner/ReleaseTagOptions.cs
+++ b/MediaHandler.Application/Common/Models/Scanner/ReleaseTagOptions.cs
@@ -1,0 +1,28 @@
+namespace MediaHandler.Application.Common.Models.Scanner;
+
+/// <summary>
+///     Runtime-configurable release tag patterns bound from the <c>Scanner:ReleaseTags</c>
+///     configuration section via <c>IOptionsMonitor&lt;ReleaseTagOptions&gt;</c>.
+///     Patterns are merged with the built-in defaults in <c>KodiNameParser</c>
+///     and applied during the title-cleaning pipeline to strip release-group tags,
+///     quality identifiers, codecs, sources, and language markers that appear before
+///     the SxxExx marker in TV episode filenames.
+/// </summary>
+public sealed class ReleaseTagOptions
+{
+    /// <summary>
+    ///     Configuration section name used when binding via <c>IConfiguration</c>.
+    /// </summary>
+    public const string SectionName = "Scanner:ReleaseTags";
+
+    /// <summary>
+    ///     Additional regex patterns (case-insensitive) to strip from the pre-SxxExx
+    ///     portion of a TV episode filename, supplementing the built-in defaults.
+    ///     Each entry is a raw regex pattern string; the caller wraps it in word-boundary
+    ///     or positional anchors as appropriate.
+    ///     Example: <c>["AMZN", "DSNP", "NF"]</c> to handle streaming-source tags
+    ///     not covered by the built-in list.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalPatterns { get; set; } = [];
+}
+

--- a/MediaHandler.Application/Common/Models/Scanner/TmdbMatchModels.cs
+++ b/MediaHandler.Application/Common/Models/Scanner/TmdbMatchModels.cs
@@ -27,7 +27,21 @@ public record MatchQuery(
     int? NfoTmdbId = null,
     /// <summary>TMDB id extracted from an explicit token in the filename (second precedence).</summary>
     int? ExplicitTokenId = null,
-    string Language = "en-US");
+    string Language = "en-US",
+    /// <summary>
+    ///     Alternative title to retry with after <see cref="Title" /> exhausts all languages.
+    ///     Typically the folder-hierarchy-derived show name when it differs from the filename-derived title.
+    ///     Callers MUST ensure <c>FallbackTitle != Title</c> (set to <c>null</c> when they are equal)
+    ///     to avoid issuing duplicate TMDB calls with no benefit.
+    /// </summary>
+    string? FallbackTitle = null,
+    /// <summary>
+    ///     Ordered list of BCP-47 language tags to try for TMDB searches (e.g., <c>["fr-FR", "en-US"]</c>).
+    ///     When non-null, takes <em>full precedence</em> over <see cref="Language" /> — the matcher
+    ///     iterates this list and ignores <see cref="Language" /> entirely.
+    ///     When null, the matcher falls back to <see cref="Language" /> for backward compatibility.
+    /// </summary>
+    IReadOnlyList<string>? SearchLanguages = null);
 
 /// <summary>
 ///     Result of <c>ITmdbMatcher.ResolveAsync</c>.

--- a/MediaHandler.Domain/Entities/LibraryRoot.cs
+++ b/MediaHandler.Domain/Entities/LibraryRoot.cs
@@ -29,6 +29,15 @@ public class LibraryRoot : BaseEntity
     /// </summary>
     public bool IsEnabled { get; set; } = true;
 
+    /// <summary>
+    ///     Ordered list of BCP-47 language tags used for TMDB searches scoped to this root
+    ///     (e.g., <c>["fr-FR", "en-US"]</c> for a French-language TV library).
+    ///     When non-null, overrides the global <c>Scanner:DefaultSearchLanguages</c> setting.
+    ///     When null, the scanner falls back to the global default language sequence.
+    ///     Persisted as a JSONB column; mapped in <c>LibraryRootConfiguration</c>.
+    /// </summary>
+    public IReadOnlyList<string>? SearchLanguages { get; set; }
+
     // ── Navigation ──────────────────────────────────────────────────────────
 
     /// <summary>All <c>MediaFile</c> rows whose physical location lies under this root.</summary>

--- a/MediaHandler.Infrastructure/DependencyInjection.cs
+++ b/MediaHandler.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models.Scanner;
 using MediaHandler.Domain.Enums;
 using MediaHandler.Infrastructure.Nas;
 using MediaHandler.Infrastructure.Nas.Scanner;
@@ -47,6 +48,11 @@ public static class DependencyInjection
             .Bind(configuration.GetSection(NasOptions.Section))
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        // Scanner options — IOptionsMonitor<ReleaseTagOptions> is available for injection
+        // by any service that needs runtime-reloadable release-tag pattern configuration.
+        services.AddOptions<ReleaseTagOptions>()
+            .Bind(configuration.GetSection(ReleaseTagOptions.SectionName));
 
         services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<MediaHandlerDbContext>());
 

--- a/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
+++ b/MediaHandler.Infrastructure/MediaHandler.Infrastructure.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.Designer.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.Designer.cs
@@ -142,7 +142,8 @@ namespace MediaHandler.Infrastructure.Migrations
                         .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("SearchLanguages")
-                        .HasColumnType("jsonb");
+                        .HasMaxLength(2000)
+                        .HasColumnType("nvarchar(2000)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");

--- a/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.Designer.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.Designer.cs
@@ -4,6 +4,7 @@ using MediaHandler.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MediaHandler.Infrastructure.Migrations
 {
     [DbContext(typeof(MediaHandlerDbContext))]
-    partial class MediaHandlerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503085254_AddSearchLanguagesToLibraryRoot")]
+    partial class AddSearchLanguagesToLibraryRoot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaHandler.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSearchLanguagesToLibraryRoot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SearchLanguages",
+                table: "LibraryRoots",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SearchLanguages",
+                table: "LibraryRoots");
+        }
+    }
+}

--- a/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260503085254_AddSearchLanguagesToLibraryRoot.cs
@@ -13,7 +13,8 @@ namespace MediaHandler.Infrastructure.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "SearchLanguages",
                 table: "LibraryRoots",
-                type: "jsonb",
+                type: "nvarchar(2000)",
+                maxLength: 2000,
                 nullable: true);
         }
 

--- a/MediaHandler.Infrastructure/Migrations/MediaHandlerDbContextModelSnapshot.cs
+++ b/MediaHandler.Infrastructure/Migrations/MediaHandlerDbContextModelSnapshot.cs
@@ -139,7 +139,8 @@ namespace MediaHandler.Infrastructure.Migrations
                         .HasColumnType("nvarchar(1024)");
 
                     b.Property<string>("SearchLanguages")
-                        .HasColumnType("jsonb");
+                        .HasMaxLength(2000)
+                        .HasColumnType("nvarchar(2000)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");

--- a/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
@@ -71,15 +71,19 @@ public sealed class KodiNameParser : IKodiNameParser
         var filename = Path.GetFileName(fullPath);
         var episodes = _episodeMatcher.Match(filename, hint);
 
+        var folderTitle = ResolveShowFolderTitle(fullPath);
+
         if (episodes.Count == 0)
         {
             if (hint.SeasonFromFolder.HasValue)
                 return new EpisodeNameParseResult(
                     true, ExtractShowTitle(fullPath),
                     [new EpisodeNumber(hint.SeasonFromFolder.Value, 0)],
-                    "Episode number could not be determined from filename");
+                    "Episode number could not be determined from filename",
+                    FolderTitle: folderTitle);
 
-            return new EpisodeNameParseResult(false, ExtractShowTitle(fullPath), [], "No episode pattern found");
+            return new EpisodeNameParseResult(false, ExtractShowTitle(fullPath), [],
+                "No episode pattern found", FolderTitle: folderTitle);
         }
 
         var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
@@ -90,7 +94,8 @@ public sealed class KodiNameParser : IKodiNameParser
         // are preserved in the show title for TMDB disambiguation.
         var showTitle = ExtractShowTitleFromFilename(filename);
         var episodeTitle = ExtractEpisodeTitle(filenameNoExt, episodes[0]);
-        return new EpisodeNameParseResult(true, showTitle, episodes, EpisodeTitle: episodeTitle);
+        return new EpisodeNameParseResult(true, showTitle, episodes,
+            EpisodeTitle: episodeTitle, FolderTitle: folderTitle);
     }
 
     /// <summary>
@@ -118,6 +123,100 @@ public sealed class KodiNameParser : IKodiNameParser
 
         return string.IsNullOrWhiteSpace(title) ? null : title;
     }
+
+    /// <summary>
+    ///     Resolves the TV show title by walking the folder hierarchy upward from the file path,
+    ///     skipping season-level folders, TV-root library containers, and generic media folders.
+    ///     Handles the sub-show concatenation pattern (e.g. /Law and Order/SVU/ → "Law and Order SVU")
+    ///     and ignores dotted release-pack folders (e.g. Show.Name.S04.MULTi.DVDRIP.x264/).
+    /// </summary>
+    /// <param name="fullPath">Absolute path to the episode file.</param>
+    /// <returns>The show-level folder name, or <c>null</c> if no usable folder is found.</returns>
+    internal static string? ResolveShowFolderTitle(string fullPath)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath))
+            return null;
+
+        var normalized = NormaliseSeparators(fullPath);
+        var allSegments = normalized.Split('/');
+
+        // Build a clean list of path segments: drop the filename (last) and empty entries.
+        var segments = allSegments
+            .Take(allSegments.Length - 1)
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
+
+        if (segments.Count == 0)
+            return null;
+
+        // Walk bottom-up to find the first usable show-level folder.
+        var candidateIndex = -1;
+        for (var i = segments.Count - 1; i >= 0; i--)
+        {
+            var seg = segments[i];
+
+            // Stop when we reach a TV library root — too high up to be a show name.
+            if (KodiRegexCatalog.TvRootFolderNames.Contains(seg))
+                break;
+
+            // Skip season folders, generic containers, and dotted release-pack folders.
+            if (IsSeasonFolderSegment(seg)
+                || KodiRegexCatalog.TvGenericFolderNames.Contains(seg)
+                || IsReleasePackFolder(seg))
+                continue;
+
+            candidateIndex = i;
+            break;
+        }
+
+        if (candidateIndex < 0)
+            return null;
+
+        var candidate = segments[candidateIndex];
+
+        // Check parent for sub-show concatenation (e.g. /Law and Order/SVU/).
+        if (candidateIndex == 0)
+            return candidate;
+
+        var parent = segments[candidateIndex - 1];
+
+        // Parent must itself be a plain show-name folder (not root/season/generic/pack).
+        if (string.IsNullOrEmpty(parent)
+            || KodiRegexCatalog.TvRootFolderNames.Contains(parent)
+            || IsSeasonFolderSegment(parent)
+            || KodiRegexCatalog.TvGenericFolderNames.Contains(parent)
+            || IsReleasePackFolder(parent))
+            return candidate;
+
+        // Avoid duplicating when the folder is nested inside a same-named parent
+        // (e.g. /The Wire/The Wire/).
+        if (string.Equals(parent, candidate, StringComparison.OrdinalIgnoreCase))
+            return candidate;
+
+        // Only concatenate when the grandparent is a TV-root, confirming a
+        // deliberate sub-show layout (e.g. /Séries/Law and Order/SVU/).
+        if (candidateIndex < 2)
+            return candidate;
+
+        var grandparent = segments[candidateIndex - 2];
+        if (KodiRegexCatalog.TvRootFolderNames.Contains(grandparent)
+            || string.IsNullOrEmpty(grandparent))
+            return parent + " " + candidate;
+
+        return candidate;
+    }
+
+    /// <summary>Returns <c>true</c> when <paramref name="segment" /> names a season-level folder.</summary>
+    private static bool IsSeasonFolderSegment(string segment)
+        => KodiRegexCatalog.SeasonFolderPattern.IsMatch(segment);
+
+    /// <summary>
+    ///     Returns <c>true</c> when <paramref name="segment" /> looks like a scene release-pack folder
+    ///     (e.g. <c>Show.Name.S04.MULTi.DVDRIP.x264-ETAY</c>): no spaces but contains dots.
+    ///     Legitimate show-folder names use spaces; batch/pack folders use dots as separators.
+    /// </summary>
+    private static bool IsReleasePackFolder(string segment)
+        => !segment.Contains(' ') && segment.Contains('.');
 
     private static string NormaliseSeparators(string path)
     {

--- a/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
@@ -7,8 +7,10 @@
 //   https://kodi.wiki/view/Advancedsettings.xml
 // No GPL source code from /home/tpfeifer/Repos/xbmc-master/ was consulted.
 
+using System.Text.RegularExpressions;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Application.Common.Models.Scanner;
+using Microsoft.Extensions.Options;
 
 namespace MediaHandler.Infrastructure.Nas.Scanner;
 
@@ -29,6 +31,24 @@ public sealed class KodiNameParser : IKodiNameParser
     };
 
     private readonly TvEpisodeMatcher _episodeMatcher = new();
+    private readonly IOptionsMonitor<ReleaseTagOptions>? _releaseTagOptions;
+
+    /// <summary>
+    ///     Default constructor — no options injection. Existing callers that use
+    ///     <c>new KodiNameParser()</c> continue to work unchanged; built-in
+    ///     <see cref="KodiRegexCatalog.CleanTvShowTitle" /> patterns are applied.
+    /// </summary>
+    public KodiNameParser() { }
+
+    /// <summary>
+    ///     Constructor with optional <see cref="IOptionsMonitor{ReleaseTagOptions}" /> injection.
+    ///     When provided, additional patterns from <c>Scanner:ReleaseTags:AdditionalPatterns</c>
+    ///     configuration are merged with the built-in <see cref="KodiRegexCatalog.CleanTvShowTitle" /> set.
+    /// </summary>
+    public KodiNameParser(IOptionsMonitor<ReleaseTagOptions>? releaseTagOptions)
+    {
+        _releaseTagOptions = releaseTagOptions;
+    }
 
     // =========================================================================
     // IKodiNameParser.ParseMovie
@@ -92,7 +112,7 @@ public sealed class KodiNameParser : IKodiNameParser
         // EpisodeTitle carries the text after SxxExx.
         // Year-like numbers before the SxxExx marker (e.g. "2011" in "Show.2011.S03E10")
         // are preserved in the show title for TMDB disambiguation.
-        var showTitle = ExtractShowTitleFromFilename(filename);
+        var showTitle = ExtractShowTitleFromFilename(filename, GetActiveTagPatterns());
         var episodeTitle = ExtractEpisodeTitle(filenameNoExt, episodes[0]);
         return new EpisodeNameParseResult(true, showTitle, episodes,
             EpisodeTitle: episodeTitle, FolderTitle: folderTitle);
@@ -100,13 +120,20 @@ public sealed class KodiNameParser : IKodiNameParser
 
     /// <summary>
     ///     Extracts the TV show title from an episode filename by taking all text before
-    ///     the first SxxExx marker, replacing dot/underscore separators with spaces, and trimming.
-    ///     Accented characters (é, è, ê…) are preserved. Year-like numbers before the marker
-    ///     are intentionally kept as they aid TMDB disambiguation.
+    ///     the first SxxExx marker, replacing dot/underscore separators with spaces, stripping
+    ///     known release tags (quality, codec, source, language, release-group), and trimming.
+    ///     Accented characters (é, è, ê…) and title-internal apostrophes are preserved by default
+    ///     because .NET <see cref="Regex" /> is Unicode-aware and none of the built-in patterns
+    ///     use <c>\w</c>-only anchors that would inadvertently strip non-ASCII code points.
+    ///     Year-like numbers before the marker are intentionally kept as they aid TMDB disambiguation.
     /// </summary>
     /// <param name="filename">Filename only (not full path). Extension is stripped internally.</param>
+    /// <param name="tagPatterns">
+    ///     Optional override of the tag-stripping pattern set. When <see langword="null" />,
+    ///     <see cref="KodiRegexCatalog.CleanTvShowTitle" /> is used (the built-in defaults).
+    /// </param>
     /// <returns>The cleaned show title, or <c>null</c> if no SxxExx pattern is found.</returns>
-    internal static string? ExtractShowTitleFromFilename(string filename)
+    internal static string? ExtractShowTitleFromFilename(string filename, IReadOnlyList<Regex>? tagPatterns = null)
     {
         var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
         var sxxMatch = KodiRegexCatalog.SxxExx.Match(filenameNoExt);
@@ -121,7 +148,36 @@ public sealed class KodiNameParser : IKodiNameParser
             .Replace('_', ' ')
             .Trim(' ', '-');
 
+        // Apply release-tag stripping patterns. Each pattern replaces a matched token with a
+        // single space so that surrounding words remain correctly separated after cleanup.
+        // Regex.Replace is Unicode-safe by default in .NET — accented characters (é, è, etc.)
+        // and apostrophes (D'enfer) pass through unmodified.
+        var patterns = tagPatterns ?? KodiRegexCatalog.CleanTvShowTitle;
+        foreach (var pattern in patterns)
+            title = pattern.Replace(title, " ");
+
+        // Collapse multiple consecutive spaces introduced by stripping, then trim edges.
+        title = Regex.Replace(title, @"\s{2,}", " ").Trim();
+
         return string.IsNullOrWhiteSpace(title) ? null : title;
+    }
+
+    /// <summary>
+    ///     Returns the merged set of tag-stripping regexes: the built-in
+    ///     <see cref="KodiRegexCatalog.CleanTvShowTitle" /> patterns plus any additional
+    ///     patterns configured in <c>Scanner:ReleaseTags:AdditionalPatterns</c>.
+    /// </summary>
+    private IReadOnlyList<Regex> GetActiveTagPatterns()
+    {
+        var opts = _releaseTagOptions?.CurrentValue;
+        if (opts is null || opts.AdditionalPatterns.Count == 0)
+            return KodiRegexCatalog.CleanTvShowTitle;
+
+        var merged = new List<Regex>(KodiRegexCatalog.CleanTvShowTitle);
+        foreach (var pattern in opts.AdditionalPatterns)
+            merged.Add(new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled));
+
+        return merged;
     }
 
     /// <summary>

--- a/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs
@@ -15,9 +15,8 @@ namespace MediaHandler.Infrastructure.Nas.Scanner;
 /// <summary>
 ///     Clean-room re-implementation of Kodi's movie + episode filename parsing heuristics.
 ///     <para>
-///         <b>Movie parsing rule</b> (SOURCE: Kodi wiki "File naming / Movies"):
-///         When a movie file is inside a dedicated folder, the folder name is used as the
-///         authoritative title source. The filename is parsed only as a fallback.
+///         <b>Movie parsing rule</b>: When a movie file is inside a dedicated folder, the folder
+///         name is used as the authoritative title source. The filename is parsed only as fallback.
 ///     </para>
 /// </summary>
 public sealed class KodiNameParser : IKodiNameParser
@@ -29,11 +28,8 @@ public sealed class KodiNameParser : IKodiNameParser
         "nas", "downloads", "torrents", "archive"
     };
 
-    // =========================================================================
-    // Private helpers
-    // =========================================================================
-
     private readonly TvEpisodeMatcher _episodeMatcher = new();
+
     // =========================================================================
     // IKodiNameParser.ParseMovie
     // SOURCE: https://kodi.wiki/view/Naming_video_files/Movies
@@ -49,15 +45,9 @@ public sealed class KodiNameParser : IKodiNameParser
         if (segments.Length < 2)
             return ParseFromFilename(Path.GetFileNameWithoutExtension(fullPath));
 
-        // SOURCE: Kodi wiki — the folder containing the movie file is tried first.
-        // The folder is the parent directory of the file.
-        var filename = segments[^1]; // last segment
-        var folder = segments[^2]; // parent folder
+        var filename = segments[^1];
+        var folder = segments[^2];
 
-        // If the parent folder looks like it contains a year (i.e., it's a movie-specific
-        // folder like "Inception (2010)" rather than a generic folder like "Movies"),
-        // treat it as the authoritative source.
-        // SOURCE: Kodi wiki — "The recommended naming scheme is 'Movie Title (Year)'"
         if (!IsGenericFolder(folder))
         {
             var folderResult = ParseFromFolderName(folder);
@@ -65,7 +55,6 @@ public sealed class KodiNameParser : IKodiNameParser
                 return folderResult;
         }
 
-        // Fallback to filename without extension
         return ParseFromFilename(Path.GetFileNameWithoutExtension(filename));
     }
 
@@ -79,18 +68,11 @@ public sealed class KodiNameParser : IKodiNameParser
         if (string.IsNullOrWhiteSpace(fullPath))
             return new EpisodeNameParseResult(false, null, [], "Empty path");
 
-        // Pass the full filename (with extension) to the matcher so it can strip internally.
-        // Do NOT strip here — the matcher already calls GetFileNameWithoutExtension.
         var filename = Path.GetFileName(fullPath);
         var episodes = _episodeMatcher.Match(filename, hint);
 
         if (episodes.Count == 0)
         {
-            // When the season is known from the containing folder but no episode number
-            // is in the filename, classify the file as an episode in that season with
-            // episode=0 (unknown). This lets the scanner flag it for review rather than
-            // silently discarding it.
-            // SOURCE: Observed Kodi behaviour — folder context provides season when filename lacks it.
             if (hint.SeasonFromFolder.HasValue)
                 return new EpisodeNameParseResult(
                     true, ExtractShowTitle(fullPath),
@@ -101,8 +83,40 @@ public sealed class KodiNameParser : IKodiNameParser
         }
 
         var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
-        var title = ExtractEpisodeTitle(filenameNoExt, episodes[0]);
-        return new EpisodeNameParseResult(true, title, episodes);
+
+        // Title carries the show name (text before SxxExx).
+        // EpisodeTitle carries the text after SxxExx.
+        // Year-like numbers before the SxxExx marker (e.g. "2011" in "Show.2011.S03E10")
+        // are preserved in the show title for TMDB disambiguation.
+        var showTitle = ExtractShowTitleFromFilename(filename);
+        var episodeTitle = ExtractEpisodeTitle(filenameNoExt, episodes[0]);
+        return new EpisodeNameParseResult(true, showTitle, episodes, EpisodeTitle: episodeTitle);
+    }
+
+    /// <summary>
+    ///     Extracts the TV show title from an episode filename by taking all text before
+    ///     the first SxxExx marker, replacing dot/underscore separators with spaces, and trimming.
+    ///     Accented characters (é, è, ê…) are preserved. Year-like numbers before the marker
+    ///     are intentionally kept as they aid TMDB disambiguation.
+    /// </summary>
+    /// <param name="filename">Filename only (not full path). Extension is stripped internally.</param>
+    /// <returns>The cleaned show title, or <c>null</c> if no SxxExx pattern is found.</returns>
+    internal static string? ExtractShowTitleFromFilename(string filename)
+    {
+        var filenameNoExt = Path.GetFileNameWithoutExtension(filename);
+        var sxxMatch = KodiRegexCatalog.SxxExx.Match(filenameNoExt);
+
+        if (!sxxMatch.Success)
+            return null;
+
+        var beforeSxx = filenameNoExt[..sxxMatch.Index];
+
+        var title = beforeSxx
+            .Replace('.', ' ')
+            .Replace('_', ' ')
+            .Trim(' ', '-');
+
+        return string.IsNullOrWhiteSpace(title) ? null : title;
     }
 
     private static string NormaliseSeparators(string path)
@@ -206,7 +220,7 @@ public sealed class KodiNameParser : IKodiNameParser
         return null;
     }
 
-    private static string? ExtractEpisodeTitle(string filenameNoExt, EpisodeNumber firstEp)
+    private static string? ExtractEpisodeTitle(string filenameNoExt, EpisodeNumber _)
     {
         // SOURCE: Kodi wiki — text after the SxxExx token is the episode title
         var sxxMatch = KodiRegexCatalog.SxxExx.Match(filenameNoExt);

--- a/MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs
@@ -149,6 +149,30 @@ public sealed class KodiRegexCatalog
             @"^(?:Season|Saison|Staffel)\s*\d{1,2}$|^S\d{2}$|^(?:Specials|Season\s*00|S00)$",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // =========================================================================
+    // TV show title cleaning (release-tag stripping before SxxExx)
+    // SOURCE: Observed scene/release filename conventions — tags commonly added to TV filenames
+    //         before the SxxExx marker that are NOT part of the show title.
+    // =========================================================================
+
+    // SOURCE: Observed scene naming patterns — ordered from most-specific to least-specific
+    // to avoid inadvertent substring collisions. Applied after dot/underscore → space conversion.
+    public static readonly Regex[] CleanTvShowTitle =
+    [
+        // Quality identifiers
+        new(@"\b(4K|2160p|1080p|720p|480p)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        // Video codec identifiers
+        new(@"\b(x264|x265|XviD|HEVC|AVC|H264|H265)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        // Source/release type identifiers
+        new(@"\b(BluRay|WEBRip|WEB-DL|DVDRip|HDTV|BDRip|REMUX)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        // Language identifiers
+        new(@"\b(TRUEFRENCH|VOSTFR|FRENCH|ENGLISH|MULTi|MULTI)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        // Release-group suffix at end of string: "-GROUP", "-GROUP.tv", etc.
+        // Only strips when the hyphen is preceded by a word character (guards against single-word
+        // hyphenated titles being truncated when the boundary is at end-of-string).
+        new(@"(?<=\w\w)-[A-Za-z0-9]+(\.(tv|com|net|org|info))?$", RegexOptions.Compiled),
+    ];
+
     // SOURCE: Observed NAS folder naming conventions — top-level TV library containers.
     // These folder names indicate the library root, not a show title, and must be skipped
     // when resolving the show name from the folder hierarchy.

--- a/MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs
@@ -141,6 +141,31 @@ public sealed class KodiRegexCatalog
     public static readonly Regex SpecialsFolderName =
         new(@"^(?:Specials|Season 00|S00)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // SOURCE: Observed NAS naming conventions — season-level folder detection used when
+    // resolving the show-level folder title by walking the path upward.
+    // Fully-anchored to match the complete folder segment, not a substring.
+    public static readonly Regex SeasonFolderPattern =
+        new(
+            @"^(?:Season|Saison|Staffel)\s*\d{1,2}$|^S\d{2}$|^(?:Specials|Season\s*00|S00)$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // SOURCE: Observed NAS folder naming conventions — top-level TV library containers.
+    // These folder names indicate the library root, not a show title, and must be skipped
+    // when resolving the show name from the folder hierarchy.
+    public static readonly HashSet<string> TvRootFolderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Séries", "Series", "TV Shows", "TV", "Shows"
+    };
+
+    // SOURCE: Observed NAS folder naming conventions — generic container folders with no
+    // show-title value. Mirrors the movie-scanner GenericFolderNames set.
+    public static readonly HashSet<string> TvGenericFolderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Video", "Videos", "Media", "Downloads",
+        "NAS", "Torrents", "Archive", "Content",
+        "Disque NAS 1"
+    };
+
     // =========================================================================
     // Stacking suffix patterns
     // SOURCE: Kodi wiki advancedsettings stackingregex — default stack suffixes

--- a/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
@@ -13,6 +13,7 @@ using MediaHandler.Application.Common.Models.Scanner;
 using MediaHandler.Domain.Entities;
 using MediaHandler.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace MediaHandler.Infrastructure.Nas.Scanner;
@@ -30,7 +31,8 @@ public sealed class ScanPipeline(
     ITvEpisodeMatcher episodeMatcher,
     ITmdbMatcher tmdbMatcher,
     ILogger<ScanPipeline> logger,
-    INfoParser? nfoParser = null)
+    INfoParser? nfoParser = null,
+    IConfiguration? configuration = null)
 {
     // =========================================================================
     // Public entry point
@@ -705,12 +707,27 @@ public sealed class ScanPipeline(
                 ? nfoResult.Title
                 : episodeResult.Title ?? Path.GetFileNameWithoutExtension(file.FileName);
 
+            // F2 guard: only set FallbackTitle when it differs from the filename-derived title
+            // to avoid a duplicate TMDB call with no benefit.
+            var parsedTitle = episodeResult.Title;
+            var folderTitle = episodeResult.FolderTitle;
+            var fallbackTitle = folderTitle != null && folderTitle != parsedTitle ? folderTitle : null;
+
+            // SearchLanguages priority: LibraryRoot > Scanner:DefaultSearchLanguages config > null (uses "en-US" default)
+            var searchLanguages = root.SearchLanguages is { Count: > 0 }
+                ? root.SearchLanguages
+                : configuration?.GetSection("Scanner:DefaultSearchLanguages").Get<string[]>() is { Length: > 0 } cfg
+                    ? (IReadOnlyList<string>)cfg
+                    : null;
+
             return new MatchQuery(
                 title,
                 null,
                 MediaType.TvShow,
                 nfoTmdbId,
-                explicitTokenId);
+                explicitTokenId,
+                FallbackTitle: fallbackTitle,
+                SearchLanguages: searchLanguages);
         }
     }
 

--- a/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
@@ -756,7 +756,6 @@ public sealed class ScanPipeline(
 
     // =========================================================================
     // Fingerprint: SHA-256 of "absPath|size|mtimeUnix"
-    // SOURCE: tasks.md T022 — SHA256 hex of size+mtime+absolute path
     // =========================================================================
 
     internal static string ComputeFingerprint(string absPath, long sizeBytes, DateTime mtimeUtc)

--- a/MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs
@@ -1,8 +1,10 @@
 // TmdbMatcher — resolves parsed file metadata to a TMDB entry using the precedence chain:
-//   NfoTmdbId → ExplicitTokenId → Title+Year → Title
-// Maintains an in-process LRU cache and applies the ambiguity / year-mismatch policy.
+//   NfoTmdbId → ExplicitTokenId → Multi-language title search → FallbackTitle retry → NeedsReview
+// Maintains a per-scan ConcurrentDictionary cache keyed on (title, language, year?, kind?) to
+// prevent duplicate TMDB API calls within the same scan run.
 // Transient HTTP failures are caught and surfaced as NeedsReview without aborting the scan.
 
+using System.Collections.Concurrent;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Application.Common.Models.Scanner;
 using MediaHandler.Domain.Enums;
@@ -15,13 +17,17 @@ namespace MediaHandler.Infrastructure.Nas.Scanner;
 ///     Production implementation of <see cref="ITmdbMatcher" />.
 ///     Wraps <see cref="ITmdbService" /> and applies:
 ///     <list type="bullet">
-///         <item>Precedence chain: NfoTmdbId → ExplicitTokenId → Title+Year → Title</item>
+///         <item>Precedence chain: NfoTmdbId → ExplicitTokenId → Multi-language title search → FallbackTitle → NeedsReview</item>
 ///         <item>
 ///             Ambiguity policy: ≥ 2 candidates within 5 % popularity gap →
 ///             <see cref="ReviewReason.MultipleCandidates" />
 ///         </item>
 ///         <item>Year tolerance: mismatch &gt; ±1 → <see cref="ReviewReason.YearMismatch" /></item>
-///         <item>LRU cache keyed on <c>(title, year, kind)</c> — max 1,000 entries per scan instance</item>
+///         <item>
+///             Per-scan deduplication cache keyed on <c>(title, language, year?, kind?)</c> using
+///             <see cref="ConcurrentDictionary{TKey,TValue}" />. Only successful matches are cached;
+///             NeedsReview results are not cached so transient failures can be retried.
+///         </item>
 ///         <item>Transient error tolerance: <see cref="HttpRequestException" /> caught, result surfaced as NeedsReview</item>
 ///     </list>
 /// </summary>
@@ -34,8 +40,14 @@ public sealed class TmdbMatcher : ITmdbMatcher
     // Year tolerance: if the TMDB year differs from the query year by more than this, flag as mismatch.
     private const int YearToleranceYears = 1;
 
-    // LRU cache: keyed on (title, year, kind) — stores the final TmdbMatchResult
-    private readonly LruCache<(string title, int? year, MediaType? kind), TmdbMatchResult> _cache;
+    // Per-scan deduplication cache: keyed on (title, language, year?, kind?) — stores successful matches only.
+    // Full 4-tuple key avoids cache collisions between:
+    //   • movies and TV shows with the same title (kind dimension)
+    //   • shows with the same name in different years (year dimension)
+    //   • localised searches for the same title in different languages (language dimension)
+    private readonly ConcurrentDictionary<(string title, string language, int? year, MediaType? kind), TmdbMatchResult>
+        _cache = new();
+
     private readonly ILogger<TmdbMatcher> _logger;
     private readonly ITmdbService _tmdb;
 
@@ -43,7 +55,6 @@ public sealed class TmdbMatcher : ITmdbMatcher
     {
         _tmdb = tmdb;
         _logger = logger ?? NullLogger<TmdbMatcher>.Instance;
-        _cache = new LruCache<(string, int?, MediaType?), TmdbMatchResult>(1_000);
     }
 
     /// <inheritdoc />
@@ -98,32 +109,66 @@ public sealed class TmdbMatcher : ITmdbMatcher
             return NeedsReview(ReviewReason.NoTmdbResult, []);
         }
 
-        // ── Steps 3+4: Title+Year → Title ────────────────────────────────────
-        var cacheKey = (query.Title, query.Year, query.KindHint);
-        if (_cache.TryGet(cacheKey, out var cached))
+        // ── Steps 3+4: Multi-language title search ───────────────────────────
+        // When SearchLanguages is set, iterate the full list. Otherwise fall back to the
+        // legacy Language field (defaults to "en-US") for backward compatibility.
+        var languages = query.SearchLanguages ?? [query.Language];
+
+        TmdbMatchResult? lastFailResult = null;
+
+        // Primary title — try in each language
+        foreach (var lang in languages)
         {
-            _logger.LogDebug("TMDB: cache hit for '{Title}' ({Year})", query.Title, query.Year);
-            return cached!;
+            var cacheKey = (query.Title, lang, query.Year, query.KindHint);
+            if (_cache.TryGetValue(cacheKey, out var cached))
+            {
+                _logger.LogDebug("TMDB: cache hit for '{Title}' (lang={Lang}, year={Year})",
+                    query.Title, lang, query.Year);
+                return cached;
+            }
+
+            var result = await TryResolveByTitleAsync(query with { Language = lang }, ct);
+            if (result is { NeedsReview: false })
+            {
+                _cache[cacheKey] = result;
+                return result;
+            }
+
+            lastFailResult = result;
         }
 
-        // Try Title+Year first
-        TmdbMatchResult matchResult;
-        if (query.Year.HasValue)
+        // ── Step 5: FallbackTitle retry ───────────────────────────────────────
+        // Only when FallbackTitle is set AND differs from the primary title.
+        // Callers must ensure FallbackTitle != Title to avoid a duplicate API call (F2 guard).
+        if (query.FallbackTitle is not null && query.FallbackTitle != query.Title)
         {
-            var yearCandidates = await _tmdb.SearchCandidatesAsync(
-                query.Title, query.Year, query.KindHint, query.Language, ct);
+            foreach (var lang in languages)
+            {
+                var cacheKey = (query.FallbackTitle, lang, (int?)null, query.KindHint);
+                if (_cache.TryGetValue(cacheKey, out var cached))
+                {
+                    _logger.LogDebug("TMDB: cache hit for FallbackTitle '{Title}' (lang={Lang})",
+                        query.FallbackTitle, lang);
+                    return cached;
+                }
 
-            matchResult = yearCandidates.Count > 0
-                ? ApplyPolicy(yearCandidates, query.Year)
-                : await TryTitleOnlyAsync(query, ct);
-        }
-        else
-        {
-            matchResult = await TryTitleOnlyAsync(query, ct);
+                // FallbackTitle searches are year-agnostic: the folder title may not carry
+                // the same year disambiguation as the filename-derived title.
+                var fallbackQuery = query with { Title = query.FallbackTitle, Year = null, Language = lang };
+                var result = await TryResolveByTitleAsync(fallbackQuery, ct);
+                if (result is { NeedsReview: false })
+                {
+                    _cache[cacheKey] = result;
+                    return result;
+                }
+
+                lastFailResult = result;
+            }
         }
 
-        _cache.Set(cacheKey, matchResult);
-        return matchResult;
+        // All language × title combinations exhausted — return the last failure reason so that
+        // YearMismatch / MultipleCandidates reasons surface correctly on single-language queries.
+        return lastFailResult ?? NeedsReview(ReviewReason.NoTmdbResult, []);
     }
 
     // =========================================================================
@@ -152,11 +197,28 @@ public sealed class TmdbMatcher : ITmdbMatcher
     }
 
     // =========================================================================
-    // Title-only fallback
+    // Title-based resolution — year+title first, then title-only fallback
     // =========================================================================
 
-    private async Task<TmdbMatchResult> TryTitleOnlyAsync(MatchQuery query, CancellationToken ct)
+    /// <summary>
+    ///     Attempts to resolve <paramref name="query" /> by title (+year if provided).
+    ///     Uses the year+title search when <see cref="MatchQuery.Year" /> is set, falling back to
+    ///     title-only when the year search returns zero candidates. Always applies
+    ///     <see cref="ApplyPolicy" /> to the candidate list before returning.
+    /// </summary>
+    private async Task<TmdbMatchResult> TryResolveByTitleAsync(MatchQuery query, CancellationToken ct)
     {
+        if (query.Year.HasValue)
+        {
+            var yearCandidates = await _tmdb.SearchCandidatesAsync(
+                query.Title, query.Year, query.KindHint, query.Language, ct);
+
+            if (yearCandidates.Count > 0)
+                return ApplyPolicy(yearCandidates, query.Year);
+
+            // Year search returned nothing — try title-only as fallback
+        }
+
         var candidates = await _tmdb.SearchCandidatesAsync(
             query.Title, null, query.KindHint, query.Language, ct);
 
@@ -247,50 +309,5 @@ public sealed class TmdbMatcher : ITmdbMatcher
         return src.Select(c => new TmdbCandidate(c.TmdbId, c.Kind, c.Title, c.Year, c.PopularityScore, c.PosterPath))
             .ToList();
     }
-
-    // =========================================================================
-    // Bounded LRU cache (simple linked-list + dictionary implementation)
-    // =========================================================================
-
-    private sealed class LruCache<TKey, TValue>(int capacity) where TKey : notnull
-    {
-        private readonly int _capacity = capacity;
-        private readonly LinkedList<(TKey key, TValue value)> _list = new();
-        private readonly Dictionary<TKey, LinkedListNode<(TKey key, TValue value)>> _map = new();
-
-        public bool TryGet(TKey key, out TValue? value)
-        {
-            if (!_map.TryGetValue(key, out var node))
-            {
-                value = default;
-                return false;
-            }
-
-            // Move to front (most recently used)
-            _list.Remove(node);
-            _list.AddFirst(node);
-            value = node.Value.value;
-            return true;
-        }
-
-        public void Set(TKey key, TValue value)
-        {
-            if (_map.TryGetValue(key, out var existing))
-            {
-                _list.Remove(existing);
-                _map.Remove(key);
-            }
-            else if (_map.Count >= _capacity)
-            {
-                // Evict least recently used
-                var last = _list.Last!;
-                _map.Remove(last.Value.key);
-                _list.RemoveLast();
-            }
-
-            var node = new LinkedListNode<(TKey, TValue)>((key, value));
-            _list.AddFirst(node);
-            _map[key] = node;
-        }
-    }
 }
+

--- a/MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs
+++ b/MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MediaHandler.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -20,6 +21,15 @@ public class LibraryRootConfiguration : IEntityTypeConfiguration<LibraryRoot>
 
         builder.Property(r => r.Label)
             .HasMaxLength(200);
+
+        // SearchLanguages: stored as a JSON array in a jsonb column (PostgreSQL).
+        // Null when not configured — the scanner falls back to the global default ("en-US").
+        builder.Property(r => r.SearchLanguages)
+            .HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                v => (IReadOnlyList<string>?)(JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>()))
+            .IsRequired(false);
 
         // Unique index on Path — enforces no duplicate roots
         builder.HasIndex(r => r.Path)

--- a/MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs
+++ b/MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs
@@ -22,13 +22,15 @@ public class LibraryRootConfiguration : IEntityTypeConfiguration<LibraryRoot>
         builder.Property(r => r.Label)
             .HasMaxLength(200);
 
-        // SearchLanguages: stored as a JSON array in a jsonb column (PostgreSQL).
+        // SearchLanguages: stored as a JSON array string.
+        // No explicit column type — EF Core picks the appropriate type for the provider
+        // (nvarchar(max) for SQL Server, text for PostgreSQL).
         // Null when not configured — the scanner falls back to the global default ("en-US").
         builder.Property(r => r.SearchLanguages)
-            .HasColumnType("jsonb")
+            .HasMaxLength(2000)
             .HasConversion(
-                v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                v => (IReadOnlyList<string>?)(JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>()))
+                v => v == null ? null : JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                v => v == null ? null : (IReadOnlyList<string>?)(JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>()))
             .IsRequired(false);
 
         // Unique index on Path — enforces no duplicate roots

--- a/MediaHandler.IntegrationTests/Scanner/FullScanEndToEndTests.cs
+++ b/MediaHandler.IntegrationTests/Scanner/FullScanEndToEndTests.cs
@@ -198,7 +198,7 @@ public class FullScanEndToEndTests : ScannerIntegrationTestBase
         var stackDetector = new StackingDetector();
         var episodeMatcher = new TvEpisodeMatcher();
         var tmdbMatcher = Substitute.For<ITmdbMatcher>();
-        // TMDB stub: always return needs-review=false with no TmdbId (US1 scope)
+        // TMDB stub: always return needs-review=false with no TmdbId
         tmdbMatcher.ResolveAsync(Arg.Any<MatchQuery>(), Arg.Any<CancellationToken>())
             .Returns(new TmdbMatchResult(false, null, null, false, null, []));
 
@@ -376,7 +376,7 @@ public class FullScanEndToEndTests : ScannerIntegrationTestBase
     }
 
     // =========================================================================
-    // US3 acceptance scenarios — NFO sidecar overrides filename guess
+    // NFO sidecar overrides filename guess
     // =========================================================================
 
     /// <summary>

--- a/MediaHandler.IntegrationTests/Scanner/Sc008_TitleParsingFix.cs
+++ b/MediaHandler.IntegrationTests/Scanner/Sc008_TitleParsingFix.cs
@@ -1,0 +1,356 @@
+// SC-008: Title-parsing fix — end-to-end validation that the 6 confirmed failing shows produce
+// correct ParsedTitle values in the review queue after the scanner pipeline runs.
+// No real TMDB calls are needed: the TMDB matcher is stubbed to return NeedsReview for all
+// title searches, forcing every file onto the review queue where ParsedTitle is then inspected.
+// Also includes a regression test for FR-016: resolved ReviewItems must not be re-flagged on re-scan.
+
+using FluentAssertions;
+using MediaHandler.Application.Common.DTOs;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models.Scanner;
+using MediaHandler.Application.Features.Review.Commands.ResolveReviewItem;
+using MediaHandler.Domain.Entities;
+using MediaHandler.Domain.Enums;
+using MediaHandler.Infrastructure.Nas;
+using MediaHandler.Infrastructure.Nas.Scanner;
+using MediaHandler.Infrastructure.Persistence;
+using MediaHandler.Infrastructure.Services;
+using MediaHandler.IntegrationTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace MediaHandler.IntegrationTests.Scanner;
+
+/// <summary>
+///     SC-008: End-to-end validation of the title-parsing fix.
+///     Covers the 6 confirmed acceptance scenarios from the spec plus a release-tag-only edge case,
+///     and includes a FR-016 regression guard (resolved paths not re-flagged on re-scan).
+/// </summary>
+public class Sc008_TitleParsingFix : ScannerIntegrationTestBase
+{
+    // =========================================================================
+    // Acceptance scenario helpers
+    // =========================================================================
+
+    private static NasFileInfo Dir(string path) =>
+        new(path, System.IO.Path.GetFileName(path), 0, null, DateTime.UtcNow, DateTime.UtcNow, true);
+
+    private static NasFileInfo File(string path) =>
+        new(path, System.IO.Path.GetFileName(path), 1_073_741_824, "MKV", DateTime.UtcNow, DateTime.UtcNow);
+
+    // =========================================================================
+    // Acceptance scenario 1 — Slow Horses
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_SlowHorses_ParsedTitleIsCorrect()
+    {
+        const string filePath =
+            "/nas/Séries/Slow Horses/S03/Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/Slow Horses"),
+            Dir("/nas/Séries/Slow Horses/S03"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        parsedTitle.Should().Be("Slow Horses",
+            "dots before SxxExx must be replaced with spaces; no release tags appear before the marker");
+    }
+
+    // =========================================================================
+    // Acceptance scenario 2 — Law and Order SVU (filename typo preserved)
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_LawAndOrderSvu_ParsedTitlePreservesFilenameContent()
+    {
+        const string filePath =
+            "/nas/Séries/Law and Order/SVU/S19/Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/Law and Order"),
+            Dir("/nas/Séries/Law and Order/SVU"),
+            Dir("/nas/Séries/Law and Order/SVU/S19"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        // Filename typo "SUV" is preserved in ParsedTitle (filename content is authoritative)
+        parsedTitle.Should().Be("Law and Order SUV",
+            "the parsed title reflects the filename text before SxxExx — the SUV/SVU typo is expected");
+    }
+
+    // =========================================================================
+    // Acceptance scenario 3 — The Nanny (French dub: Une Nounou Denfer)
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_TheNanny_FrenchDubTitle_NoReleaseTags()
+    {
+        const string filePath =
+            "/nas/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/The Nanny"),
+            Dir("/nas/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        parsedTitle.Should().Be("Une Nounou Denfer",
+            "dots before SxxExx must become spaces; MULTi/DVDRIP/x264 appear after SxxExx and must not appear in title");
+    }
+
+    // =========================================================================
+    // Acceptance scenario 4 — The Killing US 2011 (year preserved before SxxExx)
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_TheKillingUS_YearBeforeSxxExx_Preserved()
+    {
+        const string filePath =
+            "/nas/Séries/The Killing US/S03/The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/The Killing US"),
+            Dir("/nas/Séries/The Killing US/S03"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        parsedTitle.Should().Be("The Killing US 2011",
+            "year 2011 precedes SxxExx and must be preserved in the title for TMDB disambiguation");
+    }
+
+    // =========================================================================
+    // Acceptance scenario 5 — The Wire (French title: Sur écoute, accented é preserved)
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_TheWire_AccentedFrenchTitle_Preserved()
+    {
+        const string filePath =
+            "/nas/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/The Wire"),
+            Dir("/nas/Séries/The Wire/The Wire"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        parsedTitle.Should().Be("Sur écoute",
+            "accented character é must survive the dot→space replacement and title-cleaning pipeline");
+    }
+
+    // =========================================================================
+    // Acceptance scenario 6 — Release-tag-only edge case
+    // =========================================================================
+
+    [Fact]
+    public async Task Sc008_ReleaseTagsBeforeSxxExx_AreStripped()
+    {
+        const string filePath =
+            "/nas/Séries/My Show/S01/My.Show.1080p.MULTi.WEBRip.S01E01.mkv";
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/My Show"),
+            Dir("/nas/Séries/My Show/S01"),
+            File(filePath)
+        };
+
+        var parsedTitle = await RunAndGetParsedTitleAsync(entries, filePath);
+
+        parsedTitle.Should().Be("My Show",
+            "quality/language/source tags that appear before SxxExx must be stripped from the parsed title");
+    }
+
+    // =========================================================================
+    // FR-016 regression: resolved ReviewItem must NOT be re-flagged on re-scan
+    // =========================================================================
+
+    [Fact]
+    public async Task Fr016_RescanSuppression_ResolvedReviewItem_NotReFlagged()
+    {
+        const string filePath =
+            "/nas/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv";
+        const int resolvedTmdbId = 1438;
+
+        var entries = new[]
+        {
+            Dir("/nas/Séries"),
+            Dir("/nas/Séries/The Wire"),
+            Dir("/nas/Séries/The Wire/The Wire"),
+            File(filePath)
+        };
+
+        WithFakeNasService(entries, ["/nas"]);
+
+        var tvRoot = new LibraryRoot
+        {
+            Path = "/nas/Séries",
+            Kind = LibraryRootKind.TvShows,
+            IsEnabled = true
+        };
+        DbContext.LibraryRoots.Add(tvRoot);
+        await DbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // ── First scan: all TMDB searches return NeedsReview → ReviewItem created ─
+        var matcher1 = Substitute.For<ITmdbMatcher>();
+        matcher1.ResolveAsync(Arg.Any<MatchQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new TmdbMatchResult(false, null, null, true, ReviewReason.NoTmdbResult, []));
+
+        var coordinator1 = BuildCoordinatorWithMatcher(matcher1);
+        var handle1 = await coordinator1.StartAsync(
+            new ScanStartParameters(Guid.NewGuid(), [tvRoot.Id], ScanMode.Full),
+            TestContext.Current.CancellationToken);
+        await WaitForScanCompletionAsync(handle1.ScanRunId, 60);
+
+        var reviewItem = await DbContext.ReviewItems
+            .FirstOrDefaultAsync(r => r.FilePath == filePath && r.Status == ReviewStatus.Open,
+                TestContext.Current.CancellationToken);
+        reviewItem.Should().NotBeNull("first scan should create a ReviewItem");
+
+        // ── Resolve the ReviewItem ────────────────────────────────────────────
+        var currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.OktaId.Returns("test-admin");
+        var resolveTmdb = Substitute.For<ITmdbService>();
+        resolveTmdb.GetTvShowByIdAsync(resolvedTmdbId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new TmdbIdLookupResult(resolvedTmdbId, MediaType.TvShow, "The Wire", 2002, null));
+
+        var handler = new ResolveReviewItemCommandHandler(DbContext, resolveTmdb, currentUser);
+        var resolveResult = await handler.Handle(
+            new ResolveReviewItemCommand(reviewItem!.Id, ReviewResolutionAction.Assign, resolvedTmdbId, MediaType.TvShow),
+            TestContext.Current.CancellationToken);
+        resolveResult.IsSuccess.Should().BeTrue();
+
+        await DbContext.Entry(reviewItem).ReloadAsync(TestContext.Current.CancellationToken);
+        reviewItem.Status.Should().Be(ReviewStatus.Resolved);
+
+        // ── Second scan: resolved path must NOT produce a new Open ReviewItem ─
+        var coordinatorDb2 = new MediaHandlerDbContext(DbContextOptions);
+        WithFakeNasService(entries, ["/nas"]);
+
+        var matcher2 = Substitute.For<ITmdbMatcher>();
+        matcher2.ResolveAsync(Arg.Any<MatchQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new TmdbMatchResult(false, null, null, true, ReviewReason.NoTmdbResult, []));
+
+        var pipeline2 = new ScanPipeline(
+            coordinatorDb2,
+            new NasFileEnumerator(FakeNas!, NullLogger<NasFileEnumerator>.Instance),
+            new ExclusionEvaluator(),
+            new StackingDetector(),
+            new KodiNameParser(),
+            new TvEpisodeMatcher(),
+            matcher2,
+            NullLogger<ScanPipeline>.Instance);
+
+        var coordinator2 = CreateScanRunCoordinator(pipeline2, coordinatorDb2);
+        var handle2 = await coordinator2.StartAsync(
+            new ScanStartParameters(Guid.NewGuid(), [tvRoot.Id], ScanMode.Full),
+            TestContext.Current.CancellationToken);
+        await WaitForScanCompletionAsync(handle2.ScanRunId, 60);
+
+        var newOpenItems = await DbContext.ReviewItems
+            .AsNoTracking()
+            .CountAsync(r => r.FilePath == filePath && r.Status == ReviewStatus.Open,
+                TestContext.Current.CancellationToken);
+
+        newOpenItems.Should().Be(0,
+            "FR-016: a previously resolved ReviewItem must not be re-created on re-scan when the path is unchanged");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private async Task<string?> RunAndGetParsedTitleAsync(
+        NasFileInfo[] entries, string targetFilePath)
+    {
+        WithFakeNasService(entries, ["/nas"]);
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var tvRoot = new LibraryRoot
+        {
+            Path = "/nas/Séries",
+            Kind = LibraryRootKind.TvShows,
+            IsEnabled = true
+        };
+        DbContext.LibraryRoots.Add(tvRoot);
+        await DbContext.SaveChangesAsync(ct);
+
+        // Stub TMDB: always NeedsReview so every file reaches the review queue
+        var matcher = Substitute.For<ITmdbMatcher>();
+        matcher.ResolveAsync(Arg.Any<MatchQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new TmdbMatchResult(false, null, null, true, ReviewReason.NoTmdbResult, []));
+
+        var coordinator = BuildCoordinatorWithMatcher(matcher);
+        var handle = await coordinator.StartAsync(
+            new ScanStartParameters(Guid.NewGuid(), [tvRoot.Id], ScanMode.Full), ct);
+
+        await WaitForScanCompletionAsync(handle.ScanRunId, 60);
+
+        var reviewItem = await DbContext.ReviewItems
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.FilePath == targetFilePath, ct);
+
+        return reviewItem?.ParsedTitle;
+    }
+
+    private async Task WaitForScanCompletionAsync(Guid scanRunId, int timeoutSeconds)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            var run = await DbContext.ScanRuns.AsNoTracking()
+                .FirstOrDefaultAsync(r => r.Id == scanRunId, TestContext.Current.CancellationToken);
+
+            if (run is null) { await Task.Delay(500); continue; }
+            if (run.Status is ScanStatus.Completed or ScanStatus.Failed or ScanStatus.Cancelled)
+                return;
+
+            await Task.Delay(200, TestContext.Current.CancellationToken);
+        }
+
+        throw new TimeoutException($"Scan {scanRunId} did not complete within {timeoutSeconds}s");
+    }
+
+    private ScanRunCoordinator BuildCoordinatorWithMatcher(ITmdbMatcher matcher)
+    {
+        var coordinatorDb = new MediaHandlerDbContext(DbContextOptions);
+
+        var pipeline = new ScanPipeline(
+            coordinatorDb,
+            new NasFileEnumerator(FakeNas!, NullLogger<NasFileEnumerator>.Instance),
+            new ExclusionEvaluator(),
+            new StackingDetector(),
+            new KodiNameParser(),
+            new TvEpisodeMatcher(),
+            matcher,
+            NullLogger<ScanPipeline>.Instance);
+
+        return CreateScanRunCoordinator(pipeline, coordinatorDb);
+    }
+}
+

--- a/MediaHandler.Tests/Features/Tmdb/MediaImportServiceTests.cs
+++ b/MediaHandler.Tests/Features/Tmdb/MediaImportServiceTests.cs
@@ -40,7 +40,6 @@ public class MediaImportServiceTests
             NullLogger<MediaImportService>.Instance);
     }
 
-    // ── T025 ────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task ImportOrGetExisting_NewTmdbId_CreatesMedia()
@@ -88,7 +87,6 @@ public class MediaImportServiceTests
         _context.Medias.Count().Should().Be(1, "no duplicate Media row must be inserted");
     }
 
-    // ── T026 ────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task ImportOrGetExisting_TmdbReturnsNull_ReturnsFail()

--- a/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
+++ b/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
@@ -419,4 +419,129 @@ public class KodiNameParserTests
         result.Title.Should().Be("My Show Name",
             "underscores in pre-SxxExx text must be replaced with spaces");
     }
+
+    // =========================================================================
+    // FolderTitle: show name inferred from the folder hierarchy
+    // SOURCE: contracts/internal-contracts.md behavioral contract table
+    // =========================================================================
+
+    /// <summary>
+    ///     FolderTitle rows: (fullPath, expectedFolderTitle).
+    ///     SOURCE: contracts/internal-contracts.md — FolderTitle behavioral contract table.
+    /// </summary>
+    public static TheoryData<string, string?> FolderTitleData => new()
+    {
+        // ── Behavioral contract table (from contracts/internal-contracts.md) ───
+        // SOURCE: contracts/internal-contracts.md — "Slow Horses"
+        // Season S03 is skipped; parent "Slow Horses" is the show folder.
+        {
+            "/Séries/Slow Horses/S03/Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv",
+            "Slow Horses"
+        },
+        // SOURCE: contracts/internal-contracts.md — "Law and Order SVU"
+        // Folder hierarchy /Law and Order/SVU/S19/ → sub-show concatenation.
+        {
+            "/Séries/Law and Order/SVU/S19/Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi",
+            "Law and Order SVU"
+        },
+        // SOURCE: contracts/internal-contracts.md — "The Nanny"
+        // Release-pack folder "Une.Nounou.Denfer.S04.MULTi..." is skipped; "The Nanny" is used.
+        {
+            "/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv",
+            "The Nanny"
+        },
+        // SOURCE: contracts/internal-contracts.md — "The Wire"
+        // Duplicate nesting /The Wire/The Wire/ must not produce "The Wire The Wire".
+        {
+            "/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv",
+            "The Wire"
+        },
+        // SOURCE: contracts/internal-contracts.md — "The Killing US"
+        // Season S03 is skipped; "The Killing US" is the show folder.
+        {
+            "/Séries/The Killing US/S03/The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv",
+            "The Killing US"
+        },
+
+        // ── Season folder patterns to skip ───────────────────────────────────
+        // SOURCE: Kodi wiki — Season XX and Saison XX are standard season folder names.
+        { "/TV Shows/Breaking Bad/Season 03/Breaking.Bad.S03E01.mkv", "Breaking Bad" },
+        { "/Séries/Some Show/Saison 05/Show.S05E01.mkv", "Some Show" },
+        { "/Séries/Some Show/Specials/Show.S00E01.mkv", "Some Show" },
+
+        // ── TV-root folder names to skip ─────────────────────────────────────
+        // SOURCE: Observed NAS folder naming — top-level TV containers must not become show title.
+        { "/Series/The Sopranos/Season 01/Sopranos.S01E01.mkv", "The Sopranos" },
+        { "/TV/Show Name/S01/Show.Name.S01E01.mkv", "Show Name" },
+        { "/Shows/Sherlock/S02/Sherlock.S02E01.mkv", "Sherlock" },
+
+        // ── Generic folder names to skip ─────────────────────────────────────
+        // SOURCE: Observed NAS folder naming — generic containers must not become show title.
+        { "/Videos/My Show/S01/Show.S01E01.mkv", "My Show" },
+        { "/Media/My Show/Season 01/Show.S01E01.mkv", "My Show" },
+        { "/Downloads/My Show/S02/Show.S02E01.mkv", "My Show" },
+
+        // ── No usable folder available ────────────────────────────────────────
+        // No show-level folder can be found above season or root-only paths.
+        { "/Séries/S03/Show.S03E01.mkv", null },
+    };
+
+    [Theory]
+    [MemberData(nameof(FolderTitleData))]
+    public void ParseEpisode_FolderTitle_ResolvedFromFolderHierarchy(
+        string fullPath, string? expectedFolderTitle)
+    {
+        var result = _sut.ParseEpisode(fullPath, new EpisodeNumberingHint());
+
+        result.FolderTitle.Should().Be(expectedFolderTitle,
+            $"FolderTitle should be the show-level folder name for '{fullPath}'");
+    }
+
+    [Fact]
+    public void ParseEpisode_FolderTitle_SubShowConcatenation_LawAndOrderSvu()
+    {
+        // SOURCE: contracts/internal-contracts.md — multi-level nesting rule.
+        // /Law and Order/SVU/S19/ → parent "Law and Order" and sub-show "SVU" are concatenated
+        // because the grandparent is a TV-root folder.
+        var result = _sut.ParseEpisode(
+            "/Séries/Law and Order/SVU/S19/Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi",
+            new EpisodeNumberingHint());
+
+        result.FolderTitle.Should().Be("Law and Order SVU",
+            "SVU sub-show folders must concatenate with their parent to form the full show title");
+    }
+
+    [Fact]
+    public void ParseEpisode_FolderTitle_DuplicateFolderNames_NoDuplication()
+    {
+        // SOURCE: contracts/internal-contracts.md — The Wire uses /The Wire/The Wire/ nesting.
+        // The folder title must be "The Wire", not "The Wire The Wire".
+        var result = _sut.ParseEpisode(
+            "/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv",
+            new EpisodeNumberingHint());
+
+        result.FolderTitle.Should().Be("The Wire",
+            "duplicate parent/child folder names must not be concatenated");
+    }
+
+    [Fact]
+    public void ParseEpisode_FolderTitle_ReleasePackFolder_ParentUsedInstead()
+    {
+        // SOURCE: contracts/internal-contracts.md — The Nanny pack folder.
+        // The dotted release-pack folder must be skipped; the named show folder above is used.
+        var result = _sut.ParseEpisode(
+            "/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv",
+            new EpisodeNumberingHint());
+
+        result.FolderTitle.Should().Be("The Nanny",
+            "a release-pack folder (dotted, no spaces) must be skipped and the parent show folder used");
+    }
+
+    [Fact]
+    public void ParseEpisode_FolderTitle_EmptyPath_ReturnsNull()
+    {
+        var result = _sut.ParseEpisode(string.Empty, new EpisodeNumberingHint());
+
+        result.FolderTitle.Should().BeNull("empty path produces no folder title");
+    }
 }

--- a/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
+++ b/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
@@ -259,7 +259,7 @@ public class KodiNameParserTests
     }
 
     // =========================================================================
-    // NFO override-precedence contract (US3 mapping note)
+    // NFO override-precedence contract
     // These tests document the parser's output BEFORE NFO override is applied.
     // The pipeline replaces the parser result with NFO data when a sidecar is present.
     // SOURCE: plan.md — "NfoTmdbId → ExplicitTokenId → Title+Year → Title"
@@ -268,7 +268,8 @@ public class KodiNameParserTests
     /// <summary>
     ///     Documents a deliberately misnamed file so the reader understands why the NFO
     ///     override matters: the filename parser alone cannot produce the correct TMDB id.
-    ///     The ScanPipeline replaces the parser's title/year with NFO values (US3 wiring).
+    ///     When a movie.nfo with a tmdbid exists alongside this file, the pipeline
+    ///     replaces the parser output with the NFO's authoritative values.
     /// </summary>
     [Fact]
     public void ParseMovie_MisnamedFile_ProducesFilenameGuess_NfoWouldOverride()
@@ -293,19 +294,129 @@ public class KodiNameParserTests
     [Fact]
     public void ParseEpisode_WellFormedFilename_ProducesEpisodeResult_NfoTmdbIdWouldOverride()
     {
-        // A perfectly named episode file. Even so, when tvshow.nfo contains <tmdbid>,
-        // the pipeline passes that id as NfoTmdbId to the MatchQuery, giving it highest
-        // precedence over both this title guess and any ExplicitTokenId in the path.
         var result = _sut.ParseEpisode(
             "/nas/TV/Breaking Bad/Season 1/Breaking.Bad.S01E01.mkv",
             new EpisodeNumberingHint(1));
 
-        // The parser successfully extracts the episode numbers from the well-named file.
-        // The title output from the parser (which may be null or partial) is irrelevant
-        // when a tvshow.nfo is present — the NFO's TmdbId is used as the authoritative signal.
         result.IsSuccess.Should().BeTrue();
         result.EpisodeNumbers.Should().NotBeEmpty("well-named SxxExx file must yield at least one episode number");
         result.EpisodeNumbers[0].Season.Should().Be(1);
         result.EpisodeNumbers[0].Episode.Should().Be(1);
+    }
+
+    // =========================================================================
+    // Show title extraction: ParseEpisode.Title = SHOW title (text BEFORE SxxExx)
+    // =========================================================================
+
+    /// <summary>
+    ///     Show-title extraction rows: (fullPath, expectedShowTitle).
+    ///     SOURCE: contracts/internal-contracts.md behavioral contract table.
+    /// </summary>
+    public static TheoryData<string, string> ShowTitleFromFilenameData => new()
+    {
+        // SOURCE: contracts/internal-contracts.md — "Slow Horses"
+        // Dots are separators; text before S03E05 = "Slow.Horses." → "Slow Horses"
+        {
+            "/Séries/Slow Horses/S03/Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv",
+            "Slow Horses"
+        },
+        // SOURCE: contracts/internal-contracts.md — "Law and Order SUV" (typo preserved from filename)
+        // text before S19E23 = "Law.and.Order.SUV." → "Law and Order SUV"
+        {
+            "/Séries/Law and Order/SVU/S19/Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi",
+            "Law and Order SUV"
+        },
+        // SOURCE: contracts/internal-contracts.md — "Une Nounou Denfer"
+        // text before S04E10 = "Une.Nounou.Denfer." → "Une Nounou Denfer"
+        {
+            "/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv",
+            "Une Nounou Denfer"
+        },
+        // SOURCE: contracts/internal-contracts.md — "Sur écoute"
+        // Space-separated filename; accented é MUST be preserved.
+        // text before S04E01 = "Sur écoute " → trimmed → "Sur écoute"
+        {
+            "/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv",
+            "Sur écoute"
+        },
+        // SOURCE: contracts/internal-contracts.md — "The Killing US 2011" (year preservation)
+        // Year 2011 appears BEFORE SxxExx → must NOT be stripped; it is part of the show title.
+        // text before S03E10 = "The.Killing.US.2011." → "The Killing US 2011"
+        {
+            "/Séries/The Killing US/S03/The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv",
+            "The Killing US 2011"
+        },
+    };
+
+    /// <summary>
+    ///     Verifies that <c>ParseEpisode.Title</c> returns the show name (text before SxxExx),
+    ///     not the release-tag text after it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ShowTitleFromFilenameData))]
+    public void ParseEpisode_ShowTitle_ExtractedFromTextBeforeSxxExx(
+        string fullPath, string expectedShowTitle)
+    {
+        var result = _sut.ParseEpisode(fullPath, new EpisodeNumberingHint());
+
+        result.IsSuccess.Should().BeTrue($"'{fullPath}' must parse successfully");
+        result.Title.Should().Be(expectedShowTitle,
+            $"Title should be the show name (text before SxxExx) — not release tags — for '{Path.GetFileName(fullPath)}'");
+    }
+
+    [Fact]
+    public void ParseEpisode_YearBeforeSxxExx_IsPreservedInShowTitle()
+    {
+        // SOURCE: contracts/internal-contracts.md — year preservation rule.
+        // "The.Killing.US.2011.S03E10..." → year 2011 precedes SxxExx and must remain
+        // in the title to enable TMDB disambiguation. It is NOT stripped.
+        var result = _sut.ParseEpisode(
+            "/Séries/The Killing US/S03/The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv",
+            new EpisodeNumberingHint());
+
+        result.Title.Should().Be("The Killing US 2011",
+            "a year-like number that appears before the SxxExx marker is part of the show title and must be preserved");
+    }
+
+    [Fact]
+    public void ParseEpisode_AccentedCharactersInTitle_ArePreserved()
+    {
+        // SOURCE: contracts/internal-contracts.md — accented character preservation rule.
+        // é in "Sur écoute" must survive the dot/underscore-to-space replacement.
+        var result = _sut.ParseEpisode(
+            "/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv",
+            new EpisodeNumberingHint());
+
+        result.Title.Should().Be("Sur écoute",
+            "accented characters (é, è, ê, etc.) must not be stripped or transliterated");
+    }
+
+    [Fact]
+    public void ParseEpisode_EpisodeTitleField_PopulatedWithTextAfterSxxExx()
+    {
+        // SOURCE: contracts/internal-contracts.md — EpisodeTitle carries text after SxxExx.
+        // "Sur écoute S04E01 - La fin de l'été" → EpisodeTitle = "La fin de l'été"
+        var result = _sut.ParseEpisode(
+            "/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv",
+            new EpisodeNumberingHint());
+
+        result.EpisodeTitle.Should().NotBeNull(
+            "text after SxxExx should be placed in EpisodeTitle, not Title");
+        result.EpisodeTitle.Should().Contain("fin",
+            "episode-specific title text after SxxExx must be preserved in EpisodeTitle");
+    }
+
+    [Fact]
+    public void ParseEpisode_UnderscoreSeparatedFilename_TitleExtractedCorrectly()
+    {
+        // SOURCE: Kodi wiki — underscore is a common separator in TV filenames alongside dot.
+        // Underscores before SxxExx must be replaced with spaces in the show title.
+        var result = _sut.ParseEpisode(
+            "/nas/TV/Show/S01/My_Show_Name_S01E11_720p.mkv",
+            new EpisodeNumberingHint());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Title.Should().Be("My Show Name",
+            "underscores in pre-SxxExx text must be replaced with spaces");
     }
 }

--- a/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
+++ b/MediaHandler.Tests/Scanner/KodiNameParserTests.cs
@@ -544,4 +544,87 @@ public class KodiNameParserTests
 
         result.FolderTitle.Should().BeNull("empty path produces no folder title");
     }
+
+    // =========================================================================
+    // Release tag stripping — titles with tags BEFORE the SxxExx marker
+    // SOURCE: contracts/internal-contracts.md — CleanTvShowTitle pipeline
+    // =========================================================================
+
+    /// <summary>
+    ///     Release tag stripping rows: (fullPath, expectedCleanTitle).
+    ///     Tags that appear in the filename text BEFORE the SxxExx marker must be stripped.
+    ///     Accented characters, apostrophes, and title-internal hyphens must be preserved.
+    ///     SOURCE: contracts/internal-contracts.md — CleanTvShowTitle requirements.
+    /// </summary>
+    public static TheoryData<string, string> ReleaseTagStrippingData => new()
+    {
+        // ── Quality tags before SxxExx ────────────────────────────────────────
+        // SOURCE: observed scene filenames — quality identifiers sometimes precede SxxExx
+        { "/nas/TV/My Show/S01/My.Show.1080p.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.720p.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.2160p.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.4K.S01E01.mkv", "My Show" },
+
+        // ── Codec tags before SxxExx ──────────────────────────────────────────
+        { "/nas/TV/My Show/S01/My.Show.x264.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.x265.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.XviD.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.HEVC.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.H264.S01E01.mkv", "My Show" },
+
+        // ── Source tags before SxxExx ─────────────────────────────────────────
+        { "/nas/TV/My Show/S01/My.Show.DVDRip.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.WEBRip.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.BluRay.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.HDTV.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.BDRip.S01E01.mkv", "My Show" },
+
+        // ── Language tags before SxxExx ───────────────────────────────────────
+        { "/nas/TV/My Show/S01/My.Show.FRENCH.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.MULTi.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.VOSTFR.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.TRUEFRENCH.S01E01.mkv", "My Show" },
+
+        // ── Release group suffix attached to last word before SxxExx ─────────
+        { "/nas/TV/Show Name/S01/Show.Name-ETAY.S01E01.mkv", "Show Name" },
+        { "/nas/TV/Show Name/S01/Show.Name-AvALoN.S01E01.mkv", "Show Name" },
+
+        // ── Multiple tags before SxxExx ───────────────────────────────────────
+        { "/nas/TV/My Show/S01/My.Show.MULTi.1080p.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.FRENCH.DVDRip.S01E01.mkv", "My Show" },
+        { "/nas/TV/My Show/S01/My.Show.720p.x264.WEBRip.S01E01.mkv", "My Show" },
+
+        // ── Accented characters MUST be preserved ─────────────────────────────
+        // SOURCE: contracts/internal-contracts.md — Unicode preservation rule.
+        { "/nas/TV/Ma Série/S01/Ma.Serie.FRENCH.S01E01.mkv", "Ma Serie" },
+
+        // ── Apostrophe in title MUST be preserved ─────────────────────────────
+        // SOURCE: contracts/internal-contracts.md — apostrophe preservation rule.
+        { "/Séries/The Nanny/S04/Une.Nounou.D'enfer.FRENCH.S04E10.mkv", "Une Nounou D'enfer" },
+    };
+
+    [Theory]
+    [MemberData(nameof(ReleaseTagStrippingData))]
+    public void ParseEpisode_ReleaseTagsBeforeSxxExx_AreStrippedFromTitle(
+        string fullPath, string expectedCleanTitle)
+    {
+        var result = _sut.ParseEpisode(fullPath, new EpisodeNumberingHint());
+
+        result.IsSuccess.Should().BeTrue($"'{fullPath}' must parse successfully");
+        result.Title.Should().Be(expectedCleanTitle,
+            $"release tags before SxxExx must be stripped from the show title for '{Path.GetFileName(fullPath)}'");
+    }
+
+    [Fact]
+    public void ParseEpisode_WEBDLBeforeSxxExx_IsStripped()
+    {
+        // WEB-DL contains a hyphen — verify the hyphen in the tag name is handled correctly.
+        var result = _sut.ParseEpisode(
+            "/nas/TV/My Show/S01/My.Show.WEB-DL.S01E01.mkv",
+            new EpisodeNumberingHint());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Title.Should().Be("My Show",
+            "WEB-DL source tag appearing before SxxExx must be stripped");
+    }
 }

--- a/MediaHandler.Tests/Scanner/NfoParserTests.cs
+++ b/MediaHandler.Tests/Scanner/NfoParserTests.cs
@@ -1,5 +1,4 @@
 // Unit tests for the NFO sidecar file parser.
-// These tests MUST fail before NfoParser.cs is implemented (T097).
 
 using FluentAssertions;
 using MediaHandler.Infrastructure.Nas.Scanner;

--- a/MediaHandler.Tests/Scanner/TmdbMatcherTests.cs
+++ b/MediaHandler.Tests/Scanner/TmdbMatcherTests.cs
@@ -135,7 +135,7 @@ public class TmdbMatcherTests
     // =========================================================================
 
     /// <remarks>
-    ///     SOURCE: tasks.md T086 — ≥ 2 candidates within 5% popularity gap → MultipleCandidates review reason.
+    ///     ≥ 2 candidates within 5% popularity gap → MultipleCandidates review reason.
     /// </remarks>
     [Fact]
     public async Task ResolveAsync_MultipleCandidatesWithinPopularityGap_ReturnsNeedsReview()
@@ -166,7 +166,7 @@ public class TmdbMatcherTests
     // =========================================================================
 
     /// <remarks>
-    ///     SOURCE: tasks.md T086 — year mismatch > ±1 → YearMismatch review reason.
+    ///     Year mismatch &gt; 1 → YearMismatch review reason.
     /// </remarks>
     [Fact]
     public async Task ResolveAsync_YearMismatch_BeyondOneTolerance_ReturnsNeedsReview()
@@ -216,7 +216,7 @@ public class TmdbMatcherTests
     // =========================================================================
 
     /// <remarks>
-    ///     SOURCE: tasks.md T086 — empty candidate list → NoTmdbResult review reason.
+    ///     Empty candidate list → NoTmdbResult review reason.
     /// </remarks>
     [Fact]
     public async Task ResolveAsync_NoResults_ReturnsNeedsReview_WithNoTmdbResultReason()
@@ -241,7 +241,7 @@ public class TmdbMatcherTests
     // =========================================================================
 
     /// <remarks>
-    ///     SOURCE: tasks.md T086 — transient HTTP errors surfaced as NeedsReview without aborting the run (FR-017).
+    ///     Transient HTTP errors are surfaced as NeedsReview without aborting the run.
     /// </remarks>
     [Fact]
     public async Task ResolveAsync_TransientHttpFailure_DoesNotThrow_ReturnsNeedsReview()
@@ -363,13 +363,13 @@ public class TmdbMatcherTests
     }
 
     // =========================================================================
-    // Override-precedence — NFO id always wins (US3 mapping note)
-    // SOURCE: plan.md US3 mapping note — NfoTmdbId precedes all other resolution signals.
+    // Override-precedence — NFO id always wins
+    // SOURCE: plan.md — NfoTmdbId precedes all other resolution signals.
     // =========================================================================
 
     /// <remarks>
     ///     When both an NFO id and an explicit filename token id are present, the NFO id wins.
-    ///     This asserts the full precedence chain: NfoTmdbId > ExplicitTokenId > Title+Year > Title.
+    ///     Full precedence chain: NfoTmdbId &gt; ExplicitTokenId &gt; Title+Year &gt; Title.
     /// </remarks>
     [Fact]
     public async Task ResolveAsync_NfoTmdbId_WinsOverExplicitTokenId()

--- a/MediaHandler.Tests/Scanner/TmdbMatcherTests.cs
+++ b/MediaHandler.Tests/Scanner/TmdbMatcherTests.cs
@@ -455,4 +455,181 @@ public class TmdbMatcherTests
             Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
             Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    // =========================================================================
+    // Multi-language TMDB search (T022)
+    // SOURCE: contracts/internal-contracts.md — ITmdbMatcher.ResolveAsync updated chain
+    // =========================================================================
+
+    /// <summary>
+    ///     Primary language match: first language in SearchLanguages resolves → second never called.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MultiLanguage_PrimaryLanguageMatches_SecondLanguageNotCalled()
+    {
+        var service = CreateService();
+
+        // fr-FR returns a match
+        service.SearchCandidatesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                "fr-FR", Arg.Any<CancellationToken>())
+            .Returns([TvShow(12345, "Une Nounou D'enfer", 1993, 80)]);
+
+        // en-US should NOT be called
+        service.SearchCandidatesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                "en-US", Arg.Any<CancellationToken>())
+            .Returns([TvShow(12345, "The Nanny", 1993, 80)]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "Une Nounou D'enfer", null, MediaType.TvShow,
+            SearchLanguages: ["fr-FR", "en-US"]);
+
+        var result = await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+
+        result.IsMatched.Should().BeTrue("title found in first language should produce a match");
+        result.NeedsReview.Should().BeFalse();
+
+        // en-US must NOT have been called since fr-FR succeeded
+        await service.DidNotReceive().SearchCandidatesAsync(
+            Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+            "en-US", Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Fallback language match: primary language returns nothing; second language finds it.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MultiLanguage_FallbackLanguageMatches()
+    {
+        var service = CreateService();
+
+        // fr-FR returns nothing
+        service.SearchCandidatesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                "fr-FR", Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // en-US returns the canonical title
+        service.SearchCandidatesAsync("Sur écoute", Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                "en-US", Arg.Any<CancellationToken>())
+            .Returns([TvShow(1438, "The Wire", 2002, 75)]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "Sur écoute", null, MediaType.TvShow,
+            SearchLanguages: ["fr-FR", "en-US"]);
+
+        var result = await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+
+        result.IsMatched.Should().BeTrue("second-language search should succeed when first is empty");
+        result.NeedsReview.Should().BeFalse();
+        result.TmdbId.Should().Be(1438);
+    }
+
+    /// <summary>
+    ///     FallbackTitle retry: primary title exhausts ALL languages, then FallbackTitle matches.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MultiLanguage_FallbackTitleRetried_AfterPrimaryExhausted()
+    {
+        var service = CreateService();
+
+        // Primary title ("Une Nounou Denfer") finds nothing in any language
+        service.SearchCandidatesAsync("Une Nounou Denfer", Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // FallbackTitle ("The Nanny") finds the correct show
+        service.SearchCandidatesAsync("The Nanny", Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                "en-US", Arg.Any<CancellationToken>())
+            .Returns([TvShow(2734, "The Nanny", 1993, 78)]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "Une Nounou Denfer", null, MediaType.TvShow,
+            FallbackTitle: "The Nanny",
+            SearchLanguages: ["fr-FR", "en-US"]);
+
+        var result = await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+
+        result.IsMatched.Should().BeTrue("FallbackTitle should be retried after primary title is exhausted");
+        result.NeedsReview.Should().BeFalse();
+        result.TmdbId.Should().Be(2734);
+    }
+
+    /// <summary>
+    ///     FallbackTitle == Title guard: when FallbackTitle equals Title, no extra TMDB call is issued.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_FallbackTitleEqualsTitle_NoDuplicateCallIssued()
+    {
+        var service = CreateService();
+
+        // Either title returns nothing → NeedsReview
+        service.SearchCandidatesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "The Wire", null, MediaType.TvShow,
+            FallbackTitle: "The Wire",       // FallbackTitle == Title → guard should prevent duplicate
+            SearchLanguages: ["en-US"]);
+
+        await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+
+        // Only one language × one title = 1 SearchCandidatesAsync call (no FallbackTitle retry)
+        await service.Received(1).SearchCandidatesAsync(
+            "The Wire", Arg.Any<int?>(), Arg.Any<MediaType?>(),
+            "en-US", Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Deduplication: same (title, language, year, kind) not called twice in same matcher instance.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MultiLanguage_SameQueryWithLanguage_UsesCachedResult()
+    {
+        var service = CreateService();
+        service.SearchCandidatesAsync("Breaking Bad", null, MediaType.TvShow, "en-US",
+                Arg.Any<CancellationToken>())
+            .Returns([TvShow(1396, "Breaking Bad", 2008, 90)]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "Breaking Bad", null, MediaType.TvShow,
+            SearchLanguages: ["en-US"]);
+
+        await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+        await matcher.ResolveAsync(query, TestContext.Current.CancellationToken); // cache hit
+
+        // Service called only once despite two resolver calls
+        await service.Received(1).SearchCandidatesAsync(
+            "Breaking Bad", Arg.Any<int?>(), Arg.Any<MediaType?>(),
+            "en-US", Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     NeedsReview: all languages and FallbackTitle exhausted → NeedsReview returned.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MultiLanguage_AllExhausted_ReturnsNeedsReview()
+    {
+        var service = CreateService();
+
+        // Nothing found under any language or title
+        service.SearchCandidatesAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<MediaType?>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var matcher = CreateMatcher(service);
+        var query = new MatchQuery(
+            "UnknownPrimary", null, MediaType.TvShow,
+            FallbackTitle: "UnknownFallback",
+            SearchLanguages: ["fr-FR", "en-US"]);
+
+        var result = await matcher.ResolveAsync(query, TestContext.Current.CancellationToken);
+
+        result.NeedsReview.Should().BeTrue("all language + FallbackTitle attempts exhausted → NeedsReview");
+        result.IsMatched.Should().BeFalse();
+    }
 }

--- a/specs/003-fix-scanner-title-parsing/checklists/requirements.md
+++ b/specs/003-fix-scanner-title-parsing/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Fix Scanner Title Parsing & TMDB Matching
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-07-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. The spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec is tightly scoped to fix the two root causes (title extraction bug + missing multi-language TMDB search) rather than redesigning the entire scanner.
+- The 7 concrete examples from the ReviewItems table serve as the primary acceptance test fixture.
+

--- a/specs/003-fix-scanner-title-parsing/contracts/internal-contracts.md
+++ b/specs/003-fix-scanner-title-parsing/contracts/internal-contracts.md
@@ -1,0 +1,117 @@
+# Internal Contracts: Scanner Title Parsing & TMDB Matching
+
+> This feature does not expose new public API endpoints. All changes are internal to the
+> scanner pipeline. This document defines the **internal interface contracts** between
+> modified components to ensure consistent integration.
+
+## IKodiNameParser.ParseEpisode — Updated Contract
+
+```csharp
+/// <summary>
+///     Parses a TV episode file path into show title, episode numbers, and folder-based fallback title.
+/// </summary>
+/// <param name="fullPath">Absolute path to the episode file.</param>
+/// <param name="hint">Season context from folder structure.</param>
+/// <returns>
+///     EpisodeNameParseResult with:
+///     - Title: show name extracted from filename (text before SxxExx, cleaned of release tags)
+///     - FolderTitle: show name from folder hierarchy (may differ from Title; null if unavailable)
+///     - Episodes: list of season+episode numbers found
+///     - EpisodeTitle: text after SxxExx (episode name or null)
+/// </returns>
+EpisodeNameParseResult ParseEpisode(string fullPath, EpisodeNumberingHint hint);
+```
+
+### Behavioral Contract
+
+| Input | Expected Title | Expected FolderTitle |
+|-------|---------------|---------------------|
+| `/Séries/Slow Horses/S03/Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv` | "Slow Horses" | "Slow Horses" |
+| `/Séries/Law and Order/SVU/S19/Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi` | "Law and Order SUV" | "Law and Order SVU" |
+| `/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv` | "Une Nounou Denfer" | "The Nanny" |
+| `/Séries/The Wire/The Wire/Sur écoute S04E01 - La fin de l'été.mkv` | "Sur écoute" | "The Wire" |
+| `/Séries/The Killing US/S03/The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv` | "The Killing US 2011" | "The Killing US" |
+
+> ℹ️ **L1 note**: The Expected Title `"Law and Order SUV"` is intentional — it preserves the typo exactly as it appears in the filename (`SUV` instead of `SVU`). Title reflects filename content; FolderTitle (`"Law and Order SVU"`) holds the correct form from the folder hierarchy. The TMDB matcher will try both.
+
+---
+
+## ITmdbMatcher.ResolveAsync — Updated Resolution Chain
+
+```csharp
+/// <summary>
+///     Resolves a MatchQuery to a TMDB entry using the precedence chain:
+///     NfoTmdbId → ExplicitTokenId → Multi-language title search → FallbackTitle search → NeedsReview
+/// </summary>
+/// <remarks>
+///     Multi-language search: iterates through query.SearchLanguages (or default ["en-US"]),
+///     trying query.Title in each language. If no match, retries with query.FallbackTitle
+///     (if non-null and different from Title) in the same language sequence.
+///     
+    ///     Deduplication: per-scan ConcurrentDictionary keyed by (title, language, year?, kind?) prevents
+    ///     duplicate TMDB API calls within the same scan run. The full 4-tuple key avoids cache collisions
+    ///     between movies and TV shows with the same title, or between shows with disambiguation year.
+/// </remarks>
+Task<TmdbMatchResult> ResolveAsync(MatchQuery query, CancellationToken ct = default);
+```
+
+### Resolution Sequence Diagram
+
+```
+ResolveAsync(query)
+│
+├─ [1] NfoTmdbId set? → LookupById → return if found
+├─ [2] ExplicitTokenId set? → LookupById → return if found
+├─ [3] For lang in (query.SearchLanguages ?? ["en-US"]):
+│      ├─ Check cache[(query.Title, lang, query.Year, query.KindHint)]
+│      ├─ SearchCandidatesAsync(query.Title, query.Year, kind, lang)
+│      └─ If match → ApplyPolicy → cache → return
+├─ [4] If query.FallbackTitle != null && != query.Title:
+│      For lang in (query.SearchLanguages ?? ["en-US"]):
+│          ├─ Check cache[(query.FallbackTitle, lang, null, kind)]
+│          ├─ SearchCandidatesAsync(query.FallbackTitle, null, kind, lang)
+│          └─ If match → ApplyPolicy → cache → return
+└─ [5] NeedsReview(NoTmdbResult)
+```
+
+---
+
+## MatchQuery Record — Updated Schema
+
+```csharp
+public record MatchQuery(
+    string Title,
+    int? Year,
+    MediaType? KindHint,
+    int? NfoTmdbId = null,
+    int? ExplicitTokenId = null,
+    string Language = "en-US",             // Kept for backward compat — IGNORED when SearchLanguages is set
+    string? FallbackTitle = null,          // NEW — must differ from Title when set
+    IReadOnlyList<string>? SearchLanguages = null  // NEW — takes full precedence over Language when non-null
+);
+```
+
+**Precedence rule**: When `SearchLanguages` is non-null and non-empty, `TmdbMatcher.ResolveAsync` iterates through it and ignores `Language`. When `SearchLanguages` is null, `["en-US"]` is used internally; `Language` is not read by new code paths.
+
+---
+
+## Configuration Contract: appsettings.json
+
+```json
+{
+  "Scanner": {
+    "ReleaseTags": {
+      "AdditionalPatterns": [],
+      "DisableDefaults": false
+    },
+    "DefaultSearchLanguages": ["en-US"]
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `Scanner:ReleaseTags:AdditionalPatterns` | `string[]` | `[]` | Extra regex patterns to strip from titles |
+| `Scanner:ReleaseTags:DisableDefaults` | `bool` | `false` | If true, only custom patterns are applied |
+| `Scanner:DefaultSearchLanguages` | `string[]` | `["en-US"]` | Global fallback when `LibraryRoot.SearchLanguages` is null |
+

--- a/specs/003-fix-scanner-title-parsing/data-model.md
+++ b/specs/003-fix-scanner-title-parsing/data-model.md
@@ -1,0 +1,172 @@
+# Data Model: Fix Scanner Title Parsing & TMDB Matching
+
+## Modified Entities
+
+### MatchQuery (Application layer — record)
+
+**File**: `MediaHandler.Application/Common/Models/Scanner/TmdbMatchModels.cs`
+
+```csharp
+public record MatchQuery(
+    string Title,
+    int? Year,
+    MediaType? KindHint,
+    int? NfoTmdbId = null,
+    int? ExplicitTokenId = null,
+    string Language = "en-US",
+    string? FallbackTitle = null,              // NEW: folder-hierarchy derived title
+    IReadOnlyList<string>? SearchLanguages = null  // NEW: ordered language list from config
+);
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Title` | `string` | Primary title extracted from filename (text before SxxExx, cleaned) |
+| `FallbackTitle` | `string?` | Secondary title from folder hierarchy; null if unavailable or same as Title |
+| `SearchLanguages` | `IReadOnlyList<string>?` | Ordered language codes for TMDB search (e.g., `["fr-FR", "en-US"]`); null = use default `["en-US"]` |
+
+**Validation rules**:
+- `Title` must not be null or whitespace (enforced by caller in `ScanPipeline.BuildMatchQuery`)
+- `FallbackTitle` must differ from `Title` when set (no point retrying the same string — enforced in `ScanPipeline.BuildMatchQuery` with: `FallbackTitle = folderTitle != parsedTitle ? folderTitle : null`)
+- `SearchLanguages` must contain valid BCP-47 language tags when provided
+
+**Precedence rule — `Language` vs `SearchLanguages`** (M4):
+- When `SearchLanguages` is **non-null and non-empty**, it takes **full precedence**; the legacy `Language` field is ignored by `TmdbMatcher.ResolveAsync`.
+- When `SearchLanguages` is **null**, `TmdbMatcher` internally uses `["en-US"]` as the effective language list. In this case the legacy `Language` field is consulted by zero new code paths; it exists solely so existing call sites that explicit-set `Language` compile without modification.
+
+---
+
+### LibraryRoot (Domain entity — extended)
+
+**File**: `MediaHandler.Domain/Entities/LibraryRoot.cs`
+
+```csharp
+public class LibraryRoot : BaseEntity
+{
+    // ...existing properties...
+
+    /// <summary>
+    ///     Ordered list of language codes for TMDB searches on files under this root.
+    ///     When null or empty, the global default ("en-US") is used.
+    ///     Stored as JSON array in the database column.
+    /// </summary>
+    public IReadOnlyList<string>? SearchLanguages { get; set; }
+}
+```
+
+| Field | Type | Storage | Description |
+|-------|------|---------|-------------|
+| `SearchLanguages` | `IReadOnlyList<string>?` | `jsonb` column | Ordered language codes for TMDB multi-language search |
+
+**EF Configuration** (in `LibraryRootConfiguration.cs`):
+```csharp
+builder.Property(e => e.SearchLanguages)
+    .HasColumnType("jsonb")
+    .HasConversion(
+        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+        v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>());
+```
+
+---
+
+### EpisodeNameParseResult (Application layer — record, extended)
+
+**File**: `MediaHandler.Application/Common/Models/Scanner/EpisodeNameParseResult.cs`
+
+Current `Title` field is repurposed — it now carries the **show title** (text before SxxExx), not the episode title.
+
+```csharp
+public record EpisodeNameParseResult(
+    bool IsSuccess,
+    string? Title,                    // Show title (from filename or folder)
+    IReadOnlyList<EpisodeNumber> EpisodeNumbers,  // ← matches actual source code (not "Episodes")
+    string? Warning = null,
+    string? EpisodeTitle = null,      // NEW: episode title (text after SxxExx)
+    string? FolderTitle = null        // NEW: show title derived from folder hierarchy
+);
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Title` | `string?` | Show title extracted from filename (before SxxExx, cleaned) |
+| `EpisodeTitle` | `string?` | Episode title (text after SxxExx); informational only |
+| `FolderTitle` | `string?` | Alternative show title from folder hierarchy; used as FallbackTitle in MatchQuery |
+
+> ⚠️ **M3 note**: The record parameter is named `EpisodeNumbers` in source (not `Episodes`). Use the correct name to avoid compilation errors.
+
+---
+
+## New Value Objects / Configuration Records
+
+### ReleaseTagOptions (Application layer — options record)
+
+**File**: `MediaHandler.Application/Common/Models/Scanner/ReleaseTagOptions.cs`
+
+```csharp
+/// <summary>
+///     Configuration-driven release tag patterns for title cleaning.
+///     Bound from appsettings.json section "Scanner:ReleaseTags".
+///     Reloaded on change via IOptionsMonitor<ReleaseTagOptions>.
+/// </summary>
+public sealed class ReleaseTagOptions
+{
+    public const string SectionName = "Scanner:ReleaseTags";
+
+    /// <summary>Additional release-group tag patterns (regex) to strip from titles.</summary>
+    public List<string> AdditionalPatterns { get; set; } = [];
+
+    /// <summary>When true, the default built-in patterns are NOT applied (custom-only mode).</summary>
+    public bool DisableDefaults { get; set; } = false;
+}
+```
+
+---
+
+## Unchanged Entities (confirmed no modification needed)
+
+| Entity | Reason |
+|--------|--------|
+| `ReviewItem` | `ParsedTitle` field already exists; will now contain correct title instead of garbage |
+| `MediaFile` | No schema change |
+| `ScanRun` | No schema change |
+| `ScanItemDecision` | No schema change |
+| `NfoMetadata` | No schema change |
+
+---
+
+## State Transitions
+
+### TMDB Resolution Chain (updated flow)
+
+```
+ParseEpisode(fullPath)
+  → Extract show title from text before SxxExx
+  → Clean: dots→spaces, strip release tags
+  → Extract folder title via hierarchy walk
+  → Return EpisodeNameParseResult { Title, FolderTitle, EpisodeTitle }
+
+BuildMatchQuery(file, root)
+  → MatchQuery { Title, FallbackTitle=FolderTitle, SearchLanguages=root.SearchLanguages }
+
+TmdbMatcher.ResolveAsync(query)
+  → For each language in query.SearchLanguages ?? ["en-US"]:
+      → Search TMDB with query.Title + language
+      → If match found → return
+  → For each language in query.SearchLanguages ?? ["en-US"]:
+      → Search TMDB with query.FallbackTitle + language (if different from Title)
+      → If match found → return
+  → Return NeedsReview
+```
+
+---
+
+## Database Migration
+
+A single EF Core migration is needed to add the `SearchLanguages` column to `LibraryRoots`:
+
+```sql
+ALTER TABLE "LibraryRoots" ADD COLUMN "SearchLanguages" jsonb NULL;
+```
+
+This is a nullable, non-breaking addition (existing rows default to null = use global default language).
+

--- a/specs/003-fix-scanner-title-parsing/plan.md
+++ b/specs/003-fix-scanner-title-parsing/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Fix Scanner Title Parsing & TMDB Matching
+
+**Branch**: `fix/scanner` | **Date**: 2025-07-15 | **Spec**: specs/003-fix-scanner-title-parsing/spec.md
+**Input**: Feature specification from `/specs/003-fix-scanner-title-parsing/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Fix the Kodi-style scanner's title extraction logic so the show name before `SxxExx` is returned (not the release tags after it), leverage folder hierarchy as a fallback/validation signal, and add multi-language TMDB search with configurable language sequences. The implementation modifies `KodiNameParser`, `TmdbMatcher`, and `MatchQuery` within the existing Clean Architecture layers — no new projects or architectural changes.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10  
+**Primary Dependencies**: MediatR, FluentValidation, EF Core (Npgsql), ASP.NET Core, Polly (resilience)  
+**Storage**: PostgreSQL via EF Core with Npgsql provider  
+**Testing**: xUnit, NSubstitute, EF Core InMemory provider, Testcontainers.PostgreSql  
+**Target Platform**: Linux server (Docker)  
+**Project Type**: Web service (REST API + background scanner pipeline)  
+**Performance Goals**: Full library scan increase ≤15%; per-scan deduplication via ConcurrentDictionary  
+**Constraints**: No new NuGet projects; changes scoped to Infrastructure (parser/matcher) and Application (models/interfaces)  
+**Scale/Scope**: Personal NAS library (~10k files); TMDB API rate-limited naturally by Polly resilience pipeline
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality — Clean Architecture | ✅ PASS | Changes to `KodiNameParser`, `TmdbMatcher` stay in Infrastructure; `MatchQuery` record in Application. Domain untouched. Dependency rule preserved. |
+| I. CQRS via MediatR | ✅ PASS | No new commands/queries needed — changes are internal to the scanner pipeline invoked by existing `StartScanCommand`. |
+| I. Result pattern | ✅ PASS | Matcher already returns `TmdbMatchResult` (success or NeedsReview); no exceptions for business errors. |
+| I. FluentValidation | ✅ N/A | No new user-input commands introduced. |
+| I. Entity configuration (Fluent API) | ✅ PASS | If `LibraryRoot` gets `SearchLanguages` column, will use `IEntityTypeConfiguration<LibraryRoot>`. |
+| I. Code style | ✅ PASS | File-scoped namespaces, `record` types, `#nullable enable` throughout. |
+| II. Testing Standards | ✅ PASS | Unit tests for parser (title extraction) + matcher (multi-language fallback). Integration tests for end-to-end scan with known failing filenames. |
+| III. User Experience | ✅ N/A | No new API endpoints; existing scan/review endpoints unchanged. |
+| IV. Performance | ✅ PASS | Per-scan ConcurrentDictionary keyed by `(title, language)` prevents duplicate TMDB calls (FR-012/SC-006). |
+| IV. HTTP resilience | ✅ PASS | `ITmdbService` already registered with `.AddStandardResilienceHandler()`. |
+| Architecture — Dependency rule | ✅ PASS | `Domain` remains zero-reference. `Application` references Domain. `Infrastructure` references both. |
+| Architecture — Secrets | ✅ PASS | TMDB API key already in user-secrets / env vars. No change needed. |
+| Workflow — Branching | ✅ PASS | Work on `fix/scanner` branch. |
+
+**Gate result**: PASS — no violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-fix-scanner-title-parsing/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (internal — no public API changes)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+MediaHandler.Domain/
+├── Entities/
+│   └── LibraryRoot.cs              # Extended: SearchLanguages property
+└── Enums/
+
+MediaHandler.Application/
+├── Common/
+│   ├── Interfaces/
+│   │   ├── IKodiNameParser.cs      # Unchanged interface
+│   │   ├── ITmdbMatcher.cs         # Unchanged interface
+│   │   └── ITmdbService.cs         # Unchanged interface
+│   └── Models/Scanner/
+│       └── TmdbMatchModels.cs      # Modified: MatchQuery gains FallbackTitle
+
+MediaHandler.Infrastructure/
+├── Nas/Scanner/
+│   ├── KodiNameParser.cs           # Modified: title extraction + folder hierarchy
+│   ├── TmdbMatcher.cs              # Modified: multi-language + fallback title
+│   ├── KodiRegexCatalog.cs         # Modified: release tag patterns for pre-SxxExx cleaning
+│   ├── TvEpisodeMatcher.cs         # Unchanged
+│   └── ScanPipeline.cs             # Modified: passes folder title + language config
+├── Persistence/Configurations/
+│   └── LibraryRootConfiguration.cs # Modified: SearchLanguages column mapping
+
+MediaHandler.Tests/
+├── Scanner/
+│   ├── KodiNameParserTests.cs      # Extended: new title extraction test cases
+│   └── TmdbMatcherTests.cs         # Extended: multi-language fallback tests
+
+MediaHandler.IntegrationTests/
+├── Scanner/
+│   └── Sc008_TitleParsingFix.cs    # New: end-to-end tests for spec acceptance scenarios
+```
+
+**Structure Decision**: Single existing solution structure is preserved. All changes land in existing projects following Clean Architecture boundaries.
+
+## Complexity Tracking
+
+> No violations found — section intentionally left empty.

--- a/specs/003-fix-scanner-title-parsing/quickstart.md
+++ b/specs/003-fix-scanner-title-parsing/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Fix Scanner Title Parsing & TMDB Matching
+
+## Overview
+
+This feature fixes the scanner's title extraction (extracting show name BEFORE `SxxExx` instead of release tags after), adds folder-hierarchy fallback, and enables multi-language TMDB search. All changes are internal to the scanner pipeline.
+
+## Prerequisites
+
+- .NET 10 SDK
+- PostgreSQL (via `docker-compose up -d`)
+- TMDB API key configured in user-secrets
+
+## Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `MediaHandler.Application/Common/Models/Scanner/TmdbMatchModels.cs` | Add `FallbackTitle` and `SearchLanguages` to `MatchQuery` |
+| `MediaHandler.Application/Common/Models/Scanner/ReleaseTagOptions.cs` | New config options class |
+| `MediaHandler.Domain/Entities/LibraryRoot.cs` | Add `SearchLanguages` property |
+| `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs` | Rewrite `ParseEpisode` title extraction + folder hierarchy |
+| `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs` | Add TV-root indicators HashSet, expose tag patterns for pre-SxxExx |
+| `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs` | Multi-language loop + FallbackTitle retry + ConcurrentDictionary cache |
+| `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs` | Pass `FolderTitle` and `SearchLanguages` into MatchQuery |
+| `MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs` | Map `SearchLanguages` as jsonb |
+
+## Implementation Order
+
+### Phase 1: Title Parser Fix (Stories 1 & 4)
+
+> ⚠️ **Dependency note**: User Story 4 (release tag stripping) builds on the `ExtractShowTitleFromFilename` method created in User Story 1. **Complete US1 implementation first** before starting US4 tag-stripping work. User Story 2 (folder hierarchy) is independent and can be developed in parallel with US1.
+
+1. **Add `ExtractShowTitleFromFilename`** to `KodiNameParser`:
+   - Find first SxxExx match position in filename
+   - Take text before that position
+   - Replace dots/underscores with spaces
+   - Strip known release tags (from `KodiRegexCatalog`) — **US4 step, requires US1 method to exist first**
+   - Trim and return
+
+2. **Add `ResolveShowFolderTitle`** to `KodiNameParser` (parallel with step 1):
+   - Walk path segments upward from file
+   - Skip season patterns (`Season XX`, `Saison XX`, `S##`, `Specials`)
+   - Skip TV-root indicators (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`) and generic folders (`Video`, `Videos`, `Media`, `Downloads`)
+   - Return first valid show-level folder name
+
+3. **Update `ParseEpisode`** to return both titles in result
+
+4. **Write unit tests** for all acceptance scenarios in spec
+
+### Phase 2: Multi-Language TMDB (Story 3)
+
+1. **Extend `MatchQuery`** with `FallbackTitle` and `SearchLanguages`
+2. **Extend `LibraryRoot`** with `SearchLanguages`; add EF migration
+3. **Rewrite `TmdbMatcher.ResolveInternalAsync`**:
+   - Replace LRU cache with `ConcurrentDictionary<(string title, string language, int? year, MediaType? kind), TmdbMatchResult>` — full 4-tuple key to avoid movie/show collisions
+   - Register `TmdbMatcher` as **Scoped** (not Singleton) so the dictionary resets per scan session
+   - Add language iteration loop
+   - Add FallbackTitle retry after primary title exhausted (only if `FallbackTitle != Title`)
+4. **Update `ScanPipeline.BuildMatchQuery`** to populate new fields (set `FallbackTitle = null` when same as Title)
+5. **Write unit + integration tests**
+
+### Phase 3: Configuration & Polish
+
+1. Add `ReleaseTagOptions` to DI + `appsettings.json`
+2. Wire `IOptionsMonitor<ReleaseTagOptions>` into `KodiNameParser`
+3. Add `Scanner:DefaultSearchLanguages` to config
+4. Verify backward compatibility (all existing tests pass)
+
+## Running Tests
+
+```bash
+# Unit tests (parser + matcher)
+dotnet test MediaHandler.Tests --filter "KodiNameParser|TmdbMatcher"
+
+# Integration tests (full scan pipeline)
+dotnet test MediaHandler.IntegrationTests --filter "Sc008"
+
+# All tests (CI gate)
+dotnet test
+```
+
+## Database Migration
+
+```bash
+dotnet ef migrations add AddSearchLanguagesToLibraryRoot \
+  --project MediaHandler.Infrastructure \
+  --startup-project MediaHandler.API
+dotnet ef database update \
+  --project MediaHandler.Infrastructure \
+  --startup-project MediaHandler.API
+```
+
+## Verification Checklist
+
+- [ ] `Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv` → Title: "Slow Horses"
+- [ ] `Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv` → Title: "Une Nounou Denfer"
+- [ ] `The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv` → Title: "The Killing US 2011"
+- [ ] `Sur écoute S04E01 - La fin de l'été.mkv` → Title: "Sur écoute"
+- [ ] French title "Une Nounou Denfer" + language `fr-FR` → TMDB matches "The Nanny"
+- [ ] FallbackTitle "The Wire" matches when "Sur écoute" fails in `en-US`
+- [ ] All existing scanner tests pass unchanged
+- [ ] Scan duration increase ≤ 15%
+

--- a/specs/003-fix-scanner-title-parsing/research.md
+++ b/specs/003-fix-scanner-title-parsing/research.md
@@ -1,0 +1,101 @@
+# Research: Fix Scanner Title Parsing & TMDB Matching
+
+## R1: Title Extraction Strategy — Before vs After SxxExx
+
+**Decision**: Extract show title from text **before** the first `SxxExx` pattern in the filename, then strip release tags from that prefix.
+
+**Rationale**: The current `KodiNameParser.ParseEpisode` delegates to `TvEpisodeMatcher` for episode number extraction but then calls `ExtractEpisodeTitle` which returns text **after** `SxxExx` — this is the *episode* title, not the *show* title. The `ExtractShowTitle` method uses a naive "hardcoded grandparent folder" approach (`segments[^3]`). The fix requires:
+1. A new `ExtractShowTitleFromFilename` method that takes text before the first `SxxExx` match
+2. Replacing dots/underscores with spaces
+3. Applying release-tag stripping to that prefix portion
+
+**Alternatives considered**:
+- Using only the folder hierarchy: Rejected because many filenames contain valid show titles, and folder-only parsing loses accuracy for well-named files.
+- Machine-learning based title extraction: Over-engineered for a personal project with deterministic filename patterns.
+
+## R2: Release Tag Stripping Before SxxExx
+
+**Decision**: Apply a curated regex-based cleanup pass to the text before `SxxExx`, removing known quality/codec/language/release-group tokens.
+
+**Rationale**: Although most release tags appear after `SxxExx`, some naming conventions (especially French re-encoders) place `MULTi`, `FRENCH`, or source tags before the season identifier in pack/folder names. The `KodiRegexCatalog.MovieCleanupTokens` array already contains the relevant patterns — it can be reused in a new `CleanTvShowTitle` helper applied to the pre-SxxExx text.
+
+**Alternatives considered**:
+- Whitelist approach (only keep known-good words): Rejected because it would fail on non-English show names with unfamiliar words.
+- Configuration-only tag list (no hardcoded patterns): Partially adopted — tags are defined in `appsettings.json` via `IOptionsMonitor<ReleaseTagOptions>` for runtime updates, but a sensible default set is compiled in.
+
+## R3: Folder Hierarchy Resolution
+
+**Decision**: Walk up from the file, skip recognized season-level folders (matching `Season XX`, `Saison XX`, `S##`, `Specials`) and TV-root indicators (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`), and use the first non-season, non-root folder as the show title.
+
+**Rationale**: The current `ExtractShowTitle` always returns `segments[^3]` which is brittle — it breaks with multi-level nesting (e.g., `/Séries/Law and Order/SVU/S19/file.mkv`). The improved algorithm:
+1. Split path into segments
+2. Walk upward from the file's containing folder
+3. Skip any segment matching season patterns (regex) or TV-root indicators (HashSet)
+4. Return the first remaining segment as the show-level folder name
+5. For multi-segment show names (e.g., `Law and Order/SVU`), concatenate non-season folders between the root indicator and the season folder
+
+**Alternatives considered**:
+- Fixed depth (always 2 levels up): Rejected because real-world libraries vary in nesting depth.
+- User-configurable depth per root: Over-engineered; the heuristic approach handles all observed layouts.
+
+## R4: Multi-Language TMDB Search Strategy
+
+**Decision**: `MatchQuery` carries an ordered list of languages (from `LibraryRoot.SearchLanguages` or global default `["en-US"]`). `TmdbMatcher` iterates through languages, calling `SearchCandidatesAsync` for each until a result is found or the list is exhausted. A per-scan `ConcurrentDictionary<(string title, string language), TmdbMatchResult>` prevents duplicate lookups.
+
+**Rationale**: The existing `ITmdbService.SearchCandidatesAsync` already accepts a `language` parameter. The fix needs only to:
+1. Call it multiple times with different language values
+2. Stop on first successful match
+3. Deduplicate across the scan run
+
+**Alternatives considered**:
+- Batch multi-language query in a single TMDB call: TMDB API does not support this.
+- Parallel language queries: Adds complexity for marginal gain; sequential is simpler and respects rate limits.
+- Language detection from filename characters: Unreliable for dot-separated ASCII filenames.
+
+## R5: FallbackTitle in MatchQuery
+
+**Decision**: Add `string? FallbackTitle` property to the `MatchQuery` record. When the primary title search fails across all languages, `TmdbMatcher` retries with `FallbackTitle` (derived from folder hierarchy) using the same language sequence.
+
+**Rationale**: The folder-hierarchy title is often in a different language than the filename (e.g., filename is French "Sur écoute" but folder is English "The Wire"). Trying both titles maximizes match rate without requiring language detection.
+
+**Alternatives considered**:
+- Separate MatchQuery per title (pipeline creates two queries): Rejected because it complicates the one-file-one-result pipeline contract and doubles ReviewItem creation logic.
+- List of candidate titles: Over-designed for the two-title case; a single `FallbackTitle` keeps the model simple.
+
+## R6: Deduplication Cache Scope & Implementation
+
+**Decision**: Replace the existing per-scan `LruCache<(string, int?, MediaType?), TmdbMatchResult>` in `TmdbMatcher` with a `ConcurrentDictionary<(string title, string language), TmdbMatchResult>` that caches by `(title, language)` pair rather than `(title, year, kind)`. This ensures the same title+language is never queried twice within a scan.
+
+**Rationale**: The spec explicitly requires per-scan-session caching keyed by `(title, language)` (FR-012). The LRU cache is good but the key doesn't include language. Switching to `ConcurrentDictionary` is simpler (no eviction needed for ~10k files) and directly satisfies the spec.
+
+**Alternatives considered**:
+- Keep LRU with expanded key: Viable but LRU eviction is unnecessary for scan-scoped lifecycles (max ~2-3k unique titles).
+- Global persistent cache (Redis/DB): Over-engineered for a personal project where TMDB results can change.
+
+## R7: Year Handling in TV Episode Filenames
+
+**Decision**: When a year-like number (4 digits, 1888-2099) appears in the text before `SxxExx`, preserve it as part of the title string. Do NOT truncate the title at the year the way movie parsing does.
+
+**Rationale**: For movies, the year is a clear title boundary (e.g., "Inception.2010.1080p"). For TV episodes, the `SxxExx` pattern is the authoritative delimiter. Year-like numbers before it (e.g., "The.Killing.US.2011.S03E10") are either part of the title or a production year hint — either way they should NOT truncate the title. The year can be extracted separately as a metadata hint for TMDB disambiguation.
+
+**Alternatives considered**:
+- Strip the year but pass it as a separate query parameter: This would truncate "The Killing US 2011" to "The Killing US" which may help TMDB. Adopted as a secondary strategy — extract the year AND keep the full title, try both.
+
+## R8: Configuration for Release Tag Catalog
+
+**Decision**: Define default release tags as a static array in `KodiRegexCatalog` (compile-time defaults). Additionally, expose an `appsettings.json` section `Scanner:ReleaseTags` that can override/extend the list at runtime via `IOptionsMonitor<ReleaseTagOptions>`.
+
+**Rationale**: The spec says tags should be reloadable without redeployment (via `IOptionsMonitor<T>`). A sane default set covers 95% of cases; power users can add niche groups.
+
+**Alternatives considered**:
+- Dedicated YAML sidecar file: Adds a non-standard config mechanism; `appsettings.json` with `IOptionsMonitor` is idiomatic .NET and already in use.
+- Database-stored tags: Over-complex for a static pattern list.
+
+## R9: Backward Compatibility — FR-016 Re-scan Suppression
+
+**Decision**: The existing ReviewItem model already stores `FilePath` and `Status`. The pipeline already checks `resolvedReviewItems` by path before running TMDB resolution (line 452 of `ScanPipeline.cs`). No changes needed — the current implementation already satisfies FR-016.
+
+**Rationale**: The code at line 452-463 of `ScanPipeline.cs` short-circuits TMDB resolution for any file path with a previously resolved ReviewItem. This behavior is keyed by absolute file path, exactly as specified.
+
+**Alternatives considered**: None needed — existing behavior is correct.
+

--- a/specs/003-fix-scanner-title-parsing/spec.md
+++ b/specs/003-fix-scanner-title-parsing/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Fix Scanner Title Parsing & TMDB Matching
+
+**Feature Branch**: `003-fix-scanner-title-parsing`  
+**Created**: 2025-07-15  
+**Status**: Draft  
+**Input**: User description: "Enhance the kodi-like scanning features — the title parser strips actual show names and keeps release tags, the scanner doesn't leverage folder hierarchy, French/localized titles aren't matched on TMDB, and the TMDB search doesn't try alternative languages."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - TV Show Title Correctly Extracted from Filename and Folder Hierarchy (Priority: P1)
+
+As an administrator scanning a NAS library of TV shows, when the scanner encounters a file such as `Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv`, the extracted show title is "Slow Horses" (the text before the SxxExx pattern, not the release tags after it). When the filename-based title extraction fails or is ambiguous, the scanner falls back to the folder hierarchy (e.g., the parent show-level folder "Slow Horses") to determine the correct show name.
+
+**Why this priority**: This is the root cause of the vast majority of ReviewItem failures. Every example in the ReviewItems table shows the parser returning release-group/quality tags instead of the actual show name. Without fixing this, every downstream TMDB lookup is doomed to fail. This single fix addresses the largest number of scan failures with the smallest scope.
+
+**Independent Test**: Scan the known failing file paths from the ReviewItems table and verify each produces the correct parsed title before any TMDB lookup is attempted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a TV episode file `Slow.Horses.S03E05.MULTi.1080p.WEBRip.x264.AC3-MULTiViSiON.mkv` inside `/Séries/Slow Horses/S03/`, **When** the scanner parses the title, **Then** the extracted show title is "Slow Horses" (from text before `S03E05`), not "MULTi 1080p WEBRip x264 AC3-MULTiViSiON".
+2. **Given** a TV episode file `New.York.Unité.Spéciale.S06E21.1080p.MULTi.WEBRiP.AvALoN.mkv` inside `/Séries/Law and Order/SVU/S06/`, **When** the scanner parses the title, **Then** the extracted show title is "New York Unité Spéciale" (from filename before `S06E21`), or falls back to the folder hierarchy "Law and Order SVU".
+3. **Given** a TV episode file `Une.Nounou.Denfer.S04E10.MULTi.DVDRIP.x264-ETAY.mkv` inside `/Séries/The Nanny/Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY/`, **When** the scanner parses the title, **Then** the extracted show title is "Une Nounou Denfer" (from filename before `S04E10`), or falls back to "The Nanny" from the grandparent folder.
+4. **Given** a TV episode file `The.Killing.US.2011.S03E10.1080p.MULTi.WEB-DL.AvALoN.mkv`, **When** the scanner parses the title, **Then** the extracted show title is "The Killing US" (text before `S03E10`, with the year `2011` stripped from the title but available as metadata).
+5. **Given** a TV episode file with a human-readable name like `Sur écoute S04E01 - La fin de l'été.mkv` inside `/Séries/The Wire/The Wire/`, **When** the scanner parses the title, **Then** the extracted show title is "Sur écoute" (text before `S04E01`), or falls back to "The Wire" from the folder hierarchy.
+6. **Given** a file where no SxxExx pattern is found in the filename but the folder structure clearly indicates a TV show (e.g., inside a `Season 03` folder), **When** the scanner parses, **Then** the show title is extracted from the folder hierarchy (show-level folder, typically 2 levels above the file).
+7. **Given** a filename where the show title contains a year (e.g., `The.Killing.US.2011.S03E10`), **When** parsing, **Then** the year is NOT mistaken for a title boundary that truncates the actual show name.
+
+---
+
+### User Story 2 - Folder Hierarchy Used as Fallback and Validation for Show Names (Priority: P1)
+
+As an administrator, when the file-level title parsing is unreliable (e.g., the filename has been mangled by encoders or uses a localized title), the scanner uses the folder hierarchy as the primary or validating signal for the show name. The typical TV show folder structure is `/root/Show Name/Season XX/file.mkv`, and the show-level folder name is a reliable, human-curated signal.
+
+**Why this priority**: The folder hierarchy is curated by the library owner and is almost always correct. Many of the reported failures would be instantly resolved if the scanner used the folder name instead of (or to validate) the filename-extracted title. This is co-equal in priority with Story 1 because some filenames are irrecoverably mangled.
+
+**Independent Test**: Scan files where the filename contains no usable show title but the parent folder clearly names the show. Verify the show title is taken from the folder.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file `random-release-name.S02E05.mkv` inside `/Séries/Breaking Bad/Season 02/`, **When** the scanner parses, **Then** the show title is "Breaking Bad" from the folder hierarchy.
+2. **Given** a file where the filename-extracted title differs from the folder name (e.g., filename says "New York Unité Spéciale" but folder says "Law and Order"), **When** the scanner parses, **Then** both titles are available for TMDB lookup — the scanner tries the filename title first and falls back to the folder title if TMDB returns no results.
+3. **Given** a multi-level folder structure with sub-folders (e.g., `/Séries/Law and Order/SVU/S19/file.mkv`), **When** the scanner parses, **Then** the scanner considers additional parent folders (not just the immediate grandparent) to construct a meaningful show name, recognizing that "SVU" alone may be insufficient but "Law and Order SVU" is meaningful.
+4. **Given** a folder structure where the season folder is named `S03` instead of `Season 03`, **When** the scanner determines the show-level folder, **Then** it correctly skips the `S03` folder (recognizing it as a season-level folder) and uses the next parent folder as the show name source.
+
+---
+
+### User Story 3 - Multi-Language TMDB Search for Localized Titles (Priority: P2)
+
+As an administrator with a library containing French (or other localized) titles alongside English originals, when the scanner extracts a title like "Une Nounou D'enfer" or "Sur écoute", the TMDB search finds the correct show even though the title is not in English. The system queries TMDB using the library's configured language(s) and, if no result is found, retries with alternative languages (at minimum: original title and English).
+
+**Why this priority**: This is the second most impactful fix. Many of the reported failures involve French-language filenames that TMDB would match if searched in the correct language. However, this depends on Story 1/2 extracting the correct title first, so it builds on the parsing fixes.
+
+**Independent Test**: Submit known French TV show titles ("Une Nounou D'enfer", "New York Unité Spéciale", "Sur écoute") to the TMDB matcher and verify they resolve to the correct English-language TMDB entries (The Nanny, Law & Order: SVU, The Wire).
+
+**Acceptance Scenarios**:
+
+1. **Given** a parsed show title "Une Nounou Denfer" (or close variant) and a library or system configured with French (`fr-FR`) as a search language, **When** the TMDB matcher runs, **Then** it finds "Une nounou d'enfer" / "The Nanny" on TMDB.
+2. **Given** a parsed show title "Sur écoute", **When** TMDB search in French returns a match, **Then** "The Wire" is correctly identified and mapped.
+3. **Given** a parsed title that returns no results in the primary configured language, **When** the matcher retries, **Then** it searches TMDB in English (`en-US`) as a fallback language before routing to the review queue.
+4. **Given** a parsed title that returns no results in any configured language but the folder-hierarchy title (e.g., "The Wire") is available, **When** the matcher retries with the folder title, **Then** it finds the correct TMDB entry.
+5. **Given** a file whose filename title and folder title are both available, **When** the primary title search fails on TMDB, **Then** the fallback title from the folder is tried before the item is sent to the review queue.
+
+---
+
+### User Story 4 - Release Tag Stripping from TV Episode Filenames (Priority: P2)
+
+As an administrator, the scanner correctly identifies and strips common release-group tags, quality identifiers, codec names, and language tags from TV episode filenames so that only the actual show title remains. Tags like `1080p`, `MULTi`, `WEBRip`, `x264`, `FRENCH`, `DVDRip`, `XviD`, `-GROUP` are never included in the parsed title.
+
+**Why this priority**: Even after fixing the "before vs after SxxExx" bug (Story 1), the text before SxxExx may still contain release tags in some naming conventions. Robust tag stripping ensures clean titles reach TMDB.
+
+**Independent Test**: Parse a collection of filenames with various release tag patterns and verify the extracted title contains none of them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a filename `Law.and.Order.SUV.S19E23.FRENCH.DVDRip.XviD-Wawacity.tv.avi`, **When** parsed, **Then** the extracted show title before `S19E23` is "Law and Order SUV" with no quality or language tags.
+2. **Given** a filename `Show.Name.S01E01.MULTI.1080p.BluRay.x264.DTS-GROUP.mkv`, **When** parsed, **Then** the show title before `S01E01` is "Show Name".
+3. **Given** a filename where release tags appear before the SxxExx pattern (e.g., a pack-style folder name like `Une.Nounou.Denfer.S04.MULTi.DVDRIP.x264-ETAY`), **When** the scanner encounters this as a folder rather than use it as a title source, **Then** the known release-group tags are stripped to yield "Une Nounou Denfer S04" (or the season token is also recognized and stripped, yielding "Une Nounou Denfer").
+
+---
+
+### Edge Cases
+
+- A filename contains no SxxExx pattern and no season/episode indicators, but resides inside a recognized TV show folder structure: the show title comes from the folder, and the item is flagged for episode number review.
+- A filename has the show title in a non-Latin script (e.g., Japanese anime titles): the parser preserves the characters and passes them to TMDB as-is; TMDB's own language-matching handles resolution.
+- The show folder name contains special characters or accented characters (e.g., "Séries", "L'Île de la tentation"): the parser handles Unicode correctly without corruption or truncation.
+- A filename has multiple year-like numbers (e.g., `The.Killing.US.2011.S03E10`): the scanner does not truncate the title at the year; for TV episodes, the SxxExx pattern is the primary delimiter, and year-like numbers before it are retained as part of the title or stripped only if they match a known year-extraction pattern.
+- The folder hierarchy has extra nesting levels (e.g., `/Séries/Law and Order/SVU/S19/file.mkv` — 4 levels deep instead of the typical 3): the scanner walks up past season-level folders to find the show-level folder.
+- A show folder name is identical to a generic folder name (e.g., "Video"): the scanner does not use it as a title and instead tries the filename.
+- Two show folders have the same base name (e.g., `/Séries/The Killing/` and `/Séries/The Killing US/` as separate folders): each is treated independently; files within each folder inherit that folder's title.
+- TMDB returns results for the localized title but the match is a different show entirely (false positive): the year, if available, is used as a disambiguation signal; otherwise the item routes to review.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Title extraction from TV episode filenames
+
+- **FR-001**: System MUST extract the show title from a TV episode filename by taking the text **before** the first SxxExx (or equivalent season/episode) pattern, after stripping dots/underscores to spaces and cleaning release-group tags.
+- **FR-002**: System MUST NOT return the text **after** the SxxExx pattern as the show title. Text after the SxxExx pattern is the episode title (or release tags), not the show name.
+- **FR-003**: System MUST strip known release-group tags, quality identifiers (720p, 1080p, 2160p, 4K), codecs (x264, x265, XviD, HEVC, AVC), sources (BluRay, WEBRip, WEB-DL, DVDRip, HDTV, BDRip), language tags (MULTI, MULTi, FRENCH, VOSTFR, TRUEFRENCH), and release group suffixes (e.g., `-GROUP`, `-Wawacity.tv`) from the extracted title portion.
+- **FR-004**: When a year-like number (e.g., `2011`) appears before the SxxExx pattern in a TV episode filename, the system MUST include it as part of the show title string passed to TMDB (e.g., "The Killing US 2011") or separately as a year hint, but MUST NOT truncate the title at the year.
+
+#### Folder hierarchy-based title resolution
+
+- **FR-005**: System MUST use the folder hierarchy as a title source for TV episodes. The show-level folder is identified by walking up from the file, skipping known season-level folders (matching patterns like `Season XX`, `Saison XX`, `SXX`, `Specials`, `Season 00`).
+- **FR-006**: System MUST treat the folder-hierarchy title as a fallback when the filename-extracted title fails to produce TMDB results, and as a primary source when the filename yields no parseable title before the SxxExx pattern.
+- **FR-007**: System MUST handle multi-level nesting (e.g., `/Show Group/Show Name/Season/file`) by skipping not just one but all season-level folders when walking up the hierarchy.
+- **FR-008**: System MUST recognize the following folder names as TV-root indicators (not show titles): "Séries", "Series", "TV Shows", "TV", "Shows" (case-insensitive), and skip them when resolving the show-level folder.
+
+#### Multi-language TMDB search
+
+- **FR-009**: System MUST support configuring an ordered list of preferred search languages per library root or globally. Administrators configure a sequence of language codes (e.g., `["fr-FR", "en-US"]`); the system tries each in order until a TMDB match is found or the list is exhausted.
+- **FR-010**: When a TMDB title search in the primary language (first in the configured sequence) returns no results, the system MUST retry the search in subsequent configured fallback languages before routing the item to the review queue. The system stops at the first language that produces a match.
+- **FR-011**: When the filename-extracted title fails TMDB search across all configured languages and a different folder-hierarchy title is available, the system MUST attempt TMDB search using the folder title (trying the same language sequence) before routing to review.
+- **FR-012**: The multi-language retry and folder-title fallback logic MUST NOT create duplicate TMDB lookups for the same (title, language) combination. A per-scan-session in-memory cache (implemented via `ConcurrentDictionary` keyed by `(title, language)`) deduplicates requests within a single scan execution.
+
+#### Title cleaning pipeline
+
+- **FR-013**: The title cleaning pipeline MUST handle accented and special characters correctly (é, è, ê, ë, ï, ü, ö, ñ, etc.) without stripping, corrupting, or transliterating them. These characters are significant for localized TMDB searches.
+- **FR-014**: The title cleaning pipeline MUST normalize common filename separators (dots, underscores, hyphens used as word separators) to spaces, but MUST preserve hyphens and apostrophes that are part of actual titles (e.g., "D'enfer", "Spider-Man").
+
+#### Backward compatibility
+
+- **FR-015**: All existing passing scan behaviors (movies, NFO handling, stacking, exclusion rules, incremental scans, review queue) MUST continue to work as specified in the 001-kodi-style-scanner spec. This feature modifies only the title extraction and TMDB search steps.
+- **FR-016**: Items previously resolved by an administrator in the review queue MUST NOT be re-flagged when the improved parser produces a different parsed title on re-scan. Resolved status is keyed by **absolute file path** alone; if the same file is scanned again with the same path, the prior resolution is suppressed and not re-inserted into the review queue.
+
+#### Key Entities
+
+- **MatchQuery** (modified): Extended with a single `string? FallbackTitle` property to carry a secondary/fallback title from the folder hierarchy, in addition to the primary filename-extracted title, so the TMDB matcher can try both. Set to `null` if no folder-hierarchy fallback is available.
+- **ReviewItem** (unchanged): Continue to record `ParsedTitle` — which will now contain the correctly extracted title instead of release-group garbage.
+- **LibraryRoot** (potentially extended): May carry a preferred TMDB search language list (ordered) if per-root language configuration is supported.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The **6** specific ReviewItem failures listed in the feature request (Law and Order SVU, The Nanny, Slow Horses, This Is Going To Hurt, The Killing US, The Wire) all produce correct show titles after parsing and successfully match on TMDB without manual intervention.
+  > ℹ️ Count corrected from "7" to "6": the spec lists exactly 6 named shows. "This Is Going To Hurt" is included in the count — it appears in the original ReviewItems table (`/Séries/This Is Going To Hurt/This.is.Going.to.Hurt.S01E06.Multi.1080p.WEBRip.x265-NoTag.mkv`) but lacks a dedicated acceptance scenario; the title extraction (text before `S01E06` = "This Is Going To Hurt") is covered by the general SxxExx parsing rules.
+- **SC-002**: On a re-scan of the production library, the number of `NoTmdbResult` ReviewItems caused by incorrect title parsing (release tags in parsed title) drops by at least 90% compared to the current scan results.
+- **SC-003**: Files with French/localized titles that correspond to known TMDB entries are matched automatically in at least 85% of cases (compared to the current 0% match rate for the reported examples).
+- **SC-004**: The title parser correctly extracts the text before SxxExx as the show title in 100% of filenames that follow the `Show.Name.SxxExx.tags.ext` convention.
+- **SC-005**: All existing scanner integration tests continue to pass without modification (backward compatibility).
+- **SC-006**: The overall scan duration for a full library scan does not increase by more than 15% due to additional TMDB language retries and folder-title fallbacks. Per-scan-session in-memory deduplication (ConcurrentDictionary cache by `(title, language, year?, kind?)` tuple) ensures that the same lookup is never issued twice within a single scan execution, keeping additional API calls minimal.
+- **SC-007**: An administrator can see the improved parsed title in the review queue for any remaining unmatched items, enabling faster manual resolution.
+
+## Clarifications
+
+### Session 2025-01-23
+
+- Q: How to model FallbackTitle in MatchQuery? → A: Add a single `string? FallbackTitle` property to `MatchQuery` to carry the folder-hierarchy-derived title alongside the primary filename-extracted title.
+- Q: TMDB language fallback strategy? → A: Configurable ordered list — admin configures a sequence of language codes per library root or globally; system tries each language in order until a hit or end of list.
+- Q: Release tag catalog storage & mutability? → A: Config file on disk (e.g., `appsettings.json` or sidecar YAML); reloaded on change without redeployment via .NET `IOptionsMonitor<T>`.
+- Q: Re-scan identity & FR-016 suppression key? → A: Resolved status keyed by absolute file path only; same path on re-scan → suppressed, not re-flagged.
+- Q: TMDB deduplication scope / SC-006 performance? → A: Per-scan-session in-memory cache (ConcurrentDictionary) keyed by `(title, language)` tuple; ensures no duplicate TMDB calls within a single scan.
+
+## Assumptions
+
+- The folder hierarchy of the production NAS library follows a recognizable pattern where the show name is a folder above the season folders. Libraries that use flat structures (all episodes in one folder) are not the primary target but should still benefit from filename-based parsing improvements.
+- The TMDB API supports search in French (`fr-FR`) and returns French-localized titles; this is a documented TMDB capability and does not require special API access.
+- The existing `ITmdbService.SearchCandidatesAsync` method already accepts a `language` parameter; the multi-language retry adds additional calls with different language values, not a new API method.
+- The set of release-group tags to strip is based on commonly observed patterns in the production library (MULTi, FRENCH, VOSTFR, TRUEFRENCH, 1080p, 720p, WEBRip, BluRay, DVDRip, x264, x265, XviD, HEVC, etc.). The catalog is maintained as a **configuration file** (e.g., `appsettings.json` or a dedicated sidecar YAML file) and is reloaded on change without redeployment via .NET's `IOptionsMonitor<T>` pattern, allowing runtime updates to the tag list.
+- "Fixing the parser" means modifying `KodiNameParser.ParseEpisode` and `ExtractEpisodeTitle`/`ExtractShowTitle` and the `TmdbMatcher` resolution chain. No architectural changes to the scan pipeline, domain model, or API surface are expected.
+- The `MediaFileNameParser` (legacy, marked `[Obsolete]`) is not in scope for these fixes — only the Kodi-style `KodiNameParser` pipeline is modified.
+- NFO-based overrides continue to take highest precedence; the title parsing and TMDB search improvements only affect the fallback chain when no NFO is present.
+

--- a/specs/003-fix-scanner-title-parsing/tasks.md
+++ b/specs/003-fix-scanner-title-parsing/tasks.md
@@ -40,10 +40,10 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T005 Add `SearchLanguages` jsonb column mapping in `MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs`
-- [ ] T006 Generate EF Core migration `AddSearchLanguagesToLibraryRoot` via `dotnet ef migrations add` (project: `MediaHandler.Infrastructure`, startup: `MediaHandler.API`)
-- [ ] T007 [P] Add `Scanner:ReleaseTags` and `Scanner:DefaultSearchLanguages` sections to `MediaHandler.API/appsettings.json`
-- [ ] T008 [P] Register `IOptionsMonitor<ReleaseTagOptions>` in DI and bind to `Scanner:ReleaseTags` config section in `MediaHandler.API/Program.cs` (or service registration extension)
+- [X] T005 Add `SearchLanguages` jsonb column mapping in `MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs`
+- [X] T006 Generate EF Core migration `AddSearchLanguagesToLibraryRoot` via `dotnet ef migrations add` (project: `MediaHandler.Infrastructure`, startup: `MediaHandler.API`)
+- [X] T007 [P] Add `Scanner:ReleaseTags` and `Scanner:DefaultSearchLanguages` sections to `MediaHandler.API/appsettings.json`
+- [X] T008 [P] Register `IOptionsMonitor<ReleaseTagOptions>` in DI and bind to `Scanner:ReleaseTags` config section in `MediaHandler.API/Program.cs` (or service registration extension)
 
 **Checkpoint**: Foundation ready — models extended, migration created, configuration wired. User story implementation can now begin.
 

--- a/specs/003-fix-scanner-title-parsing/tasks.md
+++ b/specs/003-fix-scanner-title-parsing/tasks.md
@@ -57,13 +57,13 @@
 
 ### Tests for User Story 1
 
-- [ ] T009 [P] [US1] Add unit tests for `ExtractShowTitleFromFilename` covering all acceptance scenarios (Slow Horses, New York Unité Spéciale, Une Nounou Denfer, The Killing US 2011, Sur écoute, year-handling edge cases) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+- [X] T009 [P] [US1] Add unit tests for `ExtractShowTitleFromFilename` covering all acceptance scenarios (Slow Horses, New York Unité Spéciale, Une Nounou Denfer, The Killing US 2011, Sur écoute, year-handling edge cases) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Add `ExtractShowTitleFromFilename` method to `KodiNameParser` that takes text before the first SxxExx match, replaces dots/underscores with spaces, and trims — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
-- [ ] T011 [US1] Update `ParseEpisode` in `KodiNameParser` to call `ExtractShowTitleFromFilename` and set `Title` to the show name (not episode title), and populate the new `EpisodeTitle` field with text after SxxExx — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
-- [ ] T012 [US1] Handle year-like numbers before SxxExx: preserve them in the title string and optionally extract as a separate year hint for TMDB disambiguation — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T010 [US1] Add `ExtractShowTitleFromFilename` method to `KodiNameParser` that takes text before the first SxxExx match, replaces dots/underscores with spaces, and trims — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T011 [US1] Update `ParseEpisode` in `KodiNameParser` to call `ExtractShowTitleFromFilename` and set `Title` to the show name (not episode title), and populate the new `EpisodeTitle` field with text after SxxExx — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T012 [US1] Handle year-like numbers before SxxExx: preserve them in the title string and optionally extract as a separate year hint for TMDB disambiguation — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
 
 **Checkpoint**: Title extraction from filenames is correct. Running `ParseEpisode` on known failing filenames returns the show name, not release tags.
 

--- a/specs/003-fix-scanner-title-parsing/tasks.md
+++ b/specs/003-fix-scanner-title-parsing/tasks.md
@@ -77,13 +77,13 @@
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] Add unit tests for `ResolveShowFolderTitle` covering season folder skip (`Season XX`, `Saison XX`, `S##`, `Specials`), TV-root skip (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`), multi-level nesting (`/Law and Order/SVU/S19/`), **generic folder names that must not be used as show titles** (e.g., `Video`, `Videos`, `Media`, `Downloads`), and edge cases in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+- [X] T013 [P] [US2] Add unit tests for `ResolveShowFolderTitle` covering season folder skip (`Season XX`, `Saison XX`, `S##`, `Specials`), TV-root skip (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`), multi-level nesting (`/Law and Order/SVU/S19/`), **generic folder names that must not be used as show titles** (e.g., `Video`, `Videos`, `Media`, `Downloads`), and edge cases in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T014 [P] [US2] Add TV-root indicators HashSet (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`) **and generic folder names to skip** (`Video`, `Videos`, `Media`, `Downloads` — mirrors the movie-scanner `GenericFolderNames` set) plus season-folder regex patterns to `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
-- [ ] T015 [US2] Implement `ResolveShowFolderTitle` method in `KodiNameParser` that walks path segments upward, skips season-level and TV-root folders, concatenates multi-segment show names (e.g., "Law and Order SVU"), and returns the show-level folder name — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
-- [ ] T016 [US2] Update `ParseEpisode` to call `ResolveShowFolderTitle` and populate `FolderTitle` in the returned `EpisodeNameParseResult` — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T014 [P] [US2] Add TV-root indicators HashSet (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`) **and generic folder names to skip** (`Video`, `Videos`, `Media`, `Downloads` — mirrors the movie-scanner `GenericFolderNames` set) plus season-folder regex patterns to `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
+- [X] T015 [US2] Implement `ResolveShowFolderTitle` method in `KodiNameParser` that walks path segments upward, skips season-level and TV-root folders, concatenates multi-segment show names (e.g., "Law and Order SVU"), and returns the show-level folder name — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T016 [US2] Update `ParseEpisode` to call `ResolveShowFolderTitle` and populate `FolderTitle` in the returned `EpisodeNameParseResult` — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
 
 **Checkpoint**: `ParseEpisode` now returns both `Title` (from filename) and `FolderTitle` (from folder hierarchy). Files with mangled filenames get the correct show name from the folder.
 

--- a/specs/003-fix-scanner-title-parsing/tasks.md
+++ b/specs/003-fix-scanner-title-parsing/tasks.md
@@ -1,0 +1,246 @@
+# Tasks: Fix Scanner Title Parsing & TMDB Matching
+
+**Input**: Design documents from `/specs/003-fix-scanner-title-parsing/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/internal-contracts.md, quickstart.md
+
+**Tests**: Tests are included — the spec explicitly requires unit tests (KodiNameParser, TmdbMatcher) and integration tests (end-to-end scan pipeline).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Domain**: `MediaHandler.Domain/`
+- **Application**: `MediaHandler.Application/`
+- **Infrastructure**: `MediaHandler.Infrastructure/`
+- **Unit Tests**: `MediaHandler.Tests/`
+- **Integration Tests**: `MediaHandler.IntegrationTests/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Extend shared models, configuration records, and domain entities that multiple user stories depend on
+
+- [X] T001 [P] Extend `EpisodeNameParseResult` record with `EpisodeTitle` and `FolderTitle` properties in `MediaHandler.Application/Common/Models/Scanner/NameParserModels.cs`
+- [X] T002 [P] Extend `MatchQuery` record with `FallbackTitle` and `SearchLanguages` properties in `MediaHandler.Application/Common/Models/Scanner/TmdbMatchModels.cs`
+- [X] T003 [P] Create `ReleaseTagOptions` configuration class in `MediaHandler.Application/Common/Models/Scanner/ReleaseTagOptions.cs`
+- [X] T004 [P] Add `SearchLanguages` property (`IReadOnlyList<string>?`) to `LibraryRoot` entity in `MediaHandler.Domain/Entities/LibraryRoot.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Database migration, EF configuration, and DI/config wiring that MUST be complete before any user story implementation
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Add `SearchLanguages` jsonb column mapping in `MediaHandler.Infrastructure/Persistence/Configurations/LibraryRootConfiguration.cs`
+- [ ] T006 Generate EF Core migration `AddSearchLanguagesToLibraryRoot` via `dotnet ef migrations add` (project: `MediaHandler.Infrastructure`, startup: `MediaHandler.API`)
+- [ ] T007 [P] Add `Scanner:ReleaseTags` and `Scanner:DefaultSearchLanguages` sections to `MediaHandler.API/appsettings.json`
+- [ ] T008 [P] Register `IOptionsMonitor<ReleaseTagOptions>` in DI and bind to `Scanner:ReleaseTags` config section in `MediaHandler.API/Program.cs` (or service registration extension)
+
+**Checkpoint**: Foundation ready — models extended, migration created, configuration wired. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — TV Show Title Correctly Extracted from Filename (Priority: P1) 🎯 MVP
+
+**Goal**: Fix `KodiNameParser.ParseEpisode` to extract the show title from text **before** SxxExx instead of returning release tags from after it. Handle year-like numbers correctly (e.g., `The.Killing.US.2011.S03E10` → "The Killing US 2011").
+
+**Independent Test**: Parse all known failing filenames from the ReviewItems table and verify each produces the correct show title before any TMDB lookup.
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Add unit tests for `ExtractShowTitleFromFilename` covering all acceptance scenarios (Slow Horses, New York Unité Spéciale, Une Nounou Denfer, The Killing US 2011, Sur écoute, year-handling edge cases) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Add `ExtractShowTitleFromFilename` method to `KodiNameParser` that takes text before the first SxxExx match, replaces dots/underscores with spaces, and trims — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [ ] T011 [US1] Update `ParseEpisode` in `KodiNameParser` to call `ExtractShowTitleFromFilename` and set `Title` to the show name (not episode title), and populate the new `EpisodeTitle` field with text after SxxExx — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [ ] T012 [US1] Handle year-like numbers before SxxExx: preserve them in the title string and optionally extract as a separate year hint for TMDB disambiguation — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+
+**Checkpoint**: Title extraction from filenames is correct. Running `ParseEpisode` on known failing filenames returns the show name, not release tags.
+
+---
+
+## Phase 4: User Story 2 — Folder Hierarchy Used as Fallback and Validation (Priority: P1)
+
+**Goal**: Walk the folder hierarchy upward from the file, skip season-level and TV-root folders, and return the show-level folder name as `FolderTitle` in the parse result. This serves as fallback/validation for the filename-extracted title.
+
+**Independent Test**: Parse files where the filename contains no usable show title but the parent folder clearly names the show. Verify `FolderTitle` is populated from the folder.
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] Add unit tests for `ResolveShowFolderTitle` covering season folder skip (`Season XX`, `Saison XX`, `S##`, `Specials`), TV-root skip (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`), multi-level nesting (`/Law and Order/SVU/S19/`), **generic folder names that must not be used as show titles** (e.g., `Video`, `Videos`, `Media`, `Downloads`), and edge cases in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T014 [P] [US2] Add TV-root indicators HashSet (`Séries`, `Series`, `TV Shows`, `TV`, `Shows`) **and generic folder names to skip** (`Video`, `Videos`, `Media`, `Downloads` — mirrors the movie-scanner `GenericFolderNames` set) plus season-folder regex patterns to `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
+- [ ] T015 [US2] Implement `ResolveShowFolderTitle` method in `KodiNameParser` that walks path segments upward, skips season-level and TV-root folders, concatenates multi-segment show names (e.g., "Law and Order SVU"), and returns the show-level folder name — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [ ] T016 [US2] Update `ParseEpisode` to call `ResolveShowFolderTitle` and populate `FolderTitle` in the returned `EpisodeNameParseResult` — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+
+**Checkpoint**: `ParseEpisode` now returns both `Title` (from filename) and `FolderTitle` (from folder hierarchy). Files with mangled filenames get the correct show name from the folder.
+
+---
+
+## Phase 5: User Story 4 — Release Tag Stripping from TV Episode Filenames (Priority: P2)
+
+**Goal**: Strip release-group tags, quality identifiers, codecs, sources, and language markers from the text before SxxExx so only the clean show title remains. Support runtime-configurable additional patterns via `IOptionsMonitor<ReleaseTagOptions>`.
+
+**Independent Test**: Parse filenames with various release tag patterns and verify extracted titles contain none of them.
+
+### Tests for User Story 4
+
+- [ ] T017 [P] [US4] Add unit tests for release tag stripping covering quality tags (1080p, 720p), codecs (x264, XviD), sources (DVDRip, WEBRip), language tags (MULTi, FRENCH, VOSTFR), and release group suffixes (-GROUP, -Wawacity.tv) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+
+### Implementation for User Story 4
+
+- [ ] T018 [US4] Add pre-SxxExx release tag patterns (quality, codec, source, language, release group) to `KodiRegexCatalog` — expose as a reusable `CleanTvShowTitle` regex array in `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
+- [ ] T019 [US4] Inject `IOptionsMonitor<ReleaseTagOptions>` into `KodiNameParser` and merge additional patterns with built-in defaults in `CleanTvShowTitle` application — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [ ] T020 [US4] Apply `CleanTvShowTitle` stripping in `ExtractShowTitleFromFilename` after dot/underscore replacement and before returning — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [ ] T021 [US4] Handle Unicode characters correctly in the cleaning pipeline: preserve accented characters (é, è, ê, etc.), normalize filename separators to spaces but preserve title-internal hyphens and apostrophes (e.g., "D'enfer", "Spider-Man") — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+
+**Checkpoint**: The title cleaning pipeline produces clean show titles with no release tags, while preserving accented characters and title-internal punctuation.
+
+---
+
+## Phase 6: User Story 3 — Multi-Language TMDB Search for Localized Titles (Priority: P2)
+
+**Goal**: Implement multi-language TMDB search with configurable language sequences, FallbackTitle retry, and per-scan `ConcurrentDictionary` deduplication cache. Replace the existing LRU cache in `TmdbMatcher`.
+
+**Independent Test**: Submit known French TV show titles ("Une Nounou D'enfer", "Sur écoute") to the TMDB matcher and verify they resolve to the correct TMDB entries (The Nanny, The Wire).
+
+**Depends on**: User Story 1 & 2 (correct titles must reach the matcher), User Story 4 (clean titles)
+
+### Tests for User Story 3
+
+- [ ] T022 [P] [US3] Add unit tests for multi-language TMDB resolution covering: primary language match, fallback language match, FallbackTitle retry after primary title exhausted, deduplication cache preventing duplicate API calls (same title+language+year+kind not called twice), `FallbackTitle == Title` guard (no duplicate call when both are identical), and NeedsReview when all attempts fail — in `MediaHandler.Tests/Scanner/TmdbMatcherTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Replace `LruCache<(string, int?, MediaType?), TmdbMatchResult>` with `ConcurrentDictionary<(string title, string language, int? year, MediaType? kind), TmdbMatchResult>` in `TmdbMatcher` — use the full tuple key to avoid cache collisions between queries with same title+language but different year or media type — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+  > ⚠️ **I2 fix**: Dropping `year` and `kind` from the cache key would cause incorrect cache hits (e.g., movie vs. TV show with same title). Keep the full 4-tuple key.
+  > ⚠️ **M1 — DI lifetime**: Register `TmdbMatcher` as **Scoped** (per scan-invocation), NOT Singleton. The `ConcurrentDictionary` must reset between scan runs. Ensure `ScanPipeline` resolves it from a new scope per scan execution.
+- [ ] T024 [US3] Implement multi-language iteration loop in `TmdbMatcher.ResolveAsync`: iterate through `query.SearchLanguages ?? ["en-US"]`, search TMDB with `query.Title + language`, check/update deduplication cache, and return on first match — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+- [ ] T025 [US3] Implement FallbackTitle retry in `TmdbMatcher.ResolveAsync`: after primary title exhausts all languages, retry with `query.FallbackTitle` (if non-null and different from Title) using the same language sequence — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+- [ ] T026 [US3] Update `ScanPipeline` to populate `FallbackTitle` (from `EpisodeNameParseResult.FolderTitle`, only if different from `Title`) and `SearchLanguages` (from `LibraryRoot.SearchLanguages` or global default) in `MatchQuery` construction — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
+  > ⚠️ **F2 fix**: Set `FallbackTitle = folderTitle != parsedTitle ? folderTitle : null` — never set FallbackTitle equal to Title, or the matcher will issue a duplicate TMDB call with no benefit.
+- [ ] T027 [US3] Read `Scanner:DefaultSearchLanguages` from configuration and pass as fallback when `LibraryRoot.SearchLanguages` is null — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
+
+**Checkpoint**: TMDB matcher now tries multiple languages and the folder-derived fallback title before routing to review. French titles like "Une Nounou Denfer" match via `fr-FR` search.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration tests, backward compatibility verification, and end-to-end validation
+
+- [ ] T028 [P] Create end-to-end integration test `Sc008_TitleParsingFix` covering the **6** confirmed spec acceptance scenarios (Slow Horses, Law and Order SVU, The Nanny, The Killing US, The Wire, Sur écoute) plus release-tag-only filename edge case in `MediaHandler.IntegrationTests/Scanner/Sc008_TitleParsingFix.cs`
+  > ℹ️ **A1 fix**: SC-001 originally stated "7 specific failures" but only 6 shows are confirmed in the spec. Count corrected to 6 (see spec.md SC-001 note).
+- [ ] T032 [P] Add regression test for FR-016 (re-scan suppression): verify that a file with a previously `Resolved` ReviewItem is **not** re-flagged on re-scan when the path is unchanged — guards against T023's cache refactoring accidentally breaking the resolved-path short-circuit in `ScanPipeline.cs` — in `MediaHandler.IntegrationTests/Scanner/Sc008_TitleParsingFix.cs` or dedicated `Fr016_RescanSuppressionTests.cs`
+- [ ] T029 Verify all existing scanner unit tests pass without modification (backward compatibility SC-005) — run `dotnet test MediaHandler.Tests --filter "KodiNameParser|TmdbMatcher"`
+  > ⚠️ **C2 note**: T011 changes the semantic meaning of `EpisodeNameParseResult.Title` from *episode title* to *show title*. Existing tests happen to NOT assert on `result.Title` value (confirmed at `KodiNameParserTests.cs:L214–222`), so they survive — but this is a near-miss. If any test in this suite starts asserting `result.Title == "<episode title text>"`, it will fail by design. Document this in PR description.
+- [ ] T030 Verify all existing integration tests pass without modification — run `dotnet test MediaHandler.IntegrationTests`
+- [ ] T031 Run quickstart.md verification checklist: confirm all 8 verification items pass (title extraction for known files, French title TMDB match, FallbackTitle match, existing tests green, scan duration ≤ 15% increase)
+
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately. All T001–T004 are parallelizable.
+- **Foundational (Phase 2)**: Depends on Phase 1 (T004 → T005 → T006). T007 and T008 can parallel with T005–T006.
+- **US1 (Phase 3)**: Depends on T001 (extended `EpisodeNameParseResult`). Can start after Phase 1.
+- **US2 (Phase 4)**: Depends on T001 (extended `EpisodeNameParseResult`). Can parallel with US1.
+- **US4 (Phase 5)**: Depends on US1 (builds on `ExtractShowTitleFromFilename`). Also depends on T003, T008 (ReleaseTagOptions DI).
+- **US3 (Phase 6)**: Depends on T002 (extended `MatchQuery`), US1, US2, and US4 (clean titles must reach the matcher). Also depends on T004–T006 (LibraryRoot.SearchLanguages).
+- **Polish (Phase 7)**: Depends on all user stories being complete.
+
+---
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 1 — no dependencies on other stories
+- **US2 (P1)**: Can start after Phase 1 — no dependencies on other stories, can parallel with US1
+- **US4 (P2)**: Depends on US1 (`ExtractShowTitleFromFilename` must exist to apply tag stripping to)
+- **US3 (P2)**: Depends on US1 + US2 (correct titles must reach the matcher) and T002 (MatchQuery extension)
+
+### Within Each User Story
+
+- Tests written FIRST, verify they FAIL before implementation
+- Infrastructure/catalog changes before parser/matcher changes
+- Parser changes before pipeline integration
+- Unit tests before integration tests
+
+### Parallel Opportunities
+
+- **Phase 1**: All 4 tasks (T001–T004) target different files — fully parallelizable
+- **Phase 2**: T007 and T008 can parallel with T005–T006
+- **Phase 3 & 4**: US1 and US2 can be worked in parallel (different methods in the same class, but non-overlapping)
+- **Phase 5**: Test task T017 can parallel with T018 (catalog changes)
+- **Phase 6**: Test task T022 can parallel with T023 (cache replacement)
+- **Phase 7**: T028, T032 can start while T029–T030 run existing tests
+
+---
+
+## Parallel Example: User Stories 1 & 2
+
+```
+# After Phase 1 completes, launch US1 and US2 in parallel:
+
+# Developer A — US1 (filename title extraction):
+T009: Unit tests for ExtractShowTitleFromFilename in KodiNameParserTests.cs
+T010: Implement ExtractShowTitleFromFilename in KodiNameParser.cs
+T011: Update ParseEpisode to use new method
+T012: Year-handling logic
+
+# Developer B — US2 (folder hierarchy):
+T013: Unit tests for ResolveShowFolderTitle in KodiNameParserTests.cs
+T014: TV-root indicators and season-folder patterns in KodiRegexCatalog.cs
+T015: Implement ResolveShowFolderTitle in KodiNameParser.cs
+T016: Wire FolderTitle into ParseEpisode result
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2 Only)
+
+1. Complete Phase 1: Setup (extend models)
+2. Complete Phase 2: Foundational (migration, config)
+3. Complete Phase 3: US1 — Title extraction fix
+4. Complete Phase 4: US2 — Folder hierarchy fallback
+5. **STOP and VALIDATE**: Parse all known failing filenames → verify correct titles extracted
+6. This alone resolves the root cause of the vast majority of ReviewItem failures
+
+### Incremental Delivery
+
+1. Setup + Foundational → Models and config ready
+2. US1 + US2 → Title extraction fixed → **MVP deployed** (biggest impact)
+3. US4 → Release tag stripping → Clean titles for edge cases
+4. US3 → Multi-language TMDB search → French/localized titles auto-match
+5. Polish → Integration tests, backward compat verification
+
+### Suggested MVP Scope
+
+US1 and US2 together form the natural MVP — they fix the root cause (wrong title extraction) and provide the folder fallback, which together address the vast majority of reported scan failures without requiring TMDB API changes.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US1 and US2 are both P1 and can be worked in parallel
+- US3 depends on US1+US2 producing correct titles before TMDB search
+- US4 is sequenced after US1 because it enhances the same `ExtractShowTitleFromFilename` method
+- Existing `MediaFileNameParser` (legacy, `[Obsolete]`) is NOT in scope
+- NFO-based overrides continue to take highest precedence — changes only affect the non-NFO fallback chain
+

--- a/specs/003-fix-scanner-title-parsing/tasks.md
+++ b/specs/003-fix-scanner-title-parsing/tasks.md
@@ -97,14 +97,14 @@
 
 ### Tests for User Story 4
 
-- [ ] T017 [P] [US4] Add unit tests for release tag stripping covering quality tags (1080p, 720p), codecs (x264, XviD), sources (DVDRip, WEBRip), language tags (MULTi, FRENCH, VOSTFR), and release group suffixes (-GROUP, -Wawacity.tv) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
+- [X] T017 [P] [US4] Add unit tests for release tag stripping covering quality tags (1080p, 720p), codecs (x264, XviD), sources (DVDRip, WEBRip), language tags (MULTi, FRENCH, VOSTFR), and release group suffixes (-GROUP, -Wawacity.tv) in `MediaHandler.Tests/Scanner/KodiNameParserTests.cs`
 
 ### Implementation for User Story 4
 
-- [ ] T018 [US4] Add pre-SxxExx release tag patterns (quality, codec, source, language, release group) to `KodiRegexCatalog` — expose as a reusable `CleanTvShowTitle` regex array in `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
-- [ ] T019 [US4] Inject `IOptionsMonitor<ReleaseTagOptions>` into `KodiNameParser` and merge additional patterns with built-in defaults in `CleanTvShowTitle` application — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
-- [ ] T020 [US4] Apply `CleanTvShowTitle` stripping in `ExtractShowTitleFromFilename` after dot/underscore replacement and before returning — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
-- [ ] T021 [US4] Handle Unicode characters correctly in the cleaning pipeline: preserve accented characters (é, è, ê, etc.), normalize filename separators to spaces but preserve title-internal hyphens and apostrophes (e.g., "D'enfer", "Spider-Man") — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T018 [US4] Add pre-SxxExx release tag patterns (quality, codec, source, language, release group) to `KodiRegexCatalog` — expose as a reusable `CleanTvShowTitle` regex array in `MediaHandler.Infrastructure/Nas/Scanner/KodiRegexCatalog.cs`
+- [X] T019 [US4] Inject `IOptionsMonitor<ReleaseTagOptions>` into `KodiNameParser` and merge additional patterns with built-in defaults in `CleanTvShowTitle` application — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T020 [US4] Apply `CleanTvShowTitle` stripping in `ExtractShowTitleFromFilename` after dot/underscore replacement and before returning — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
+- [X] T021 [US4] Handle Unicode characters correctly in the cleaning pipeline: preserve accented characters (é, è, ê, etc.), normalize filename separators to spaces but preserve title-internal hyphens and apostrophes (e.g., "D'enfer", "Spider-Man") — in `MediaHandler.Infrastructure/Nas/Scanner/KodiNameParser.cs`
 
 **Checkpoint**: The title cleaning pipeline produces clean show titles with no release tags, while preserving accented characters and title-internal punctuation.
 
@@ -120,18 +120,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T022 [P] [US3] Add unit tests for multi-language TMDB resolution covering: primary language match, fallback language match, FallbackTitle retry after primary title exhausted, deduplication cache preventing duplicate API calls (same title+language+year+kind not called twice), `FallbackTitle == Title` guard (no duplicate call when both are identical), and NeedsReview when all attempts fail — in `MediaHandler.Tests/Scanner/TmdbMatcherTests.cs`
+- [X] T022 [P] [US3] Add unit tests for multi-language TMDB resolution covering: primary language match, fallback language match, FallbackTitle retry after primary title exhausted, deduplication cache preventing duplicate API calls (same title+language+year+kind not called twice), `FallbackTitle == Title` guard (no duplicate call when both are identical), and NeedsReview when all attempts fail — in `MediaHandler.Tests/Scanner/TmdbMatcherTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T023 [US3] Replace `LruCache<(string, int?, MediaType?), TmdbMatchResult>` with `ConcurrentDictionary<(string title, string language, int? year, MediaType? kind), TmdbMatchResult>` in `TmdbMatcher` — use the full tuple key to avoid cache collisions between queries with same title+language but different year or media type — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
-  > ⚠️ **I2 fix**: Dropping `year` and `kind` from the cache key would cause incorrect cache hits (e.g., movie vs. TV show with same title). Keep the full 4-tuple key.
-  > ⚠️ **M1 — DI lifetime**: Register `TmdbMatcher` as **Scoped** (per scan-invocation), NOT Singleton. The `ConcurrentDictionary` must reset between scan runs. Ensure `ScanPipeline` resolves it from a new scope per scan execution.
-- [ ] T024 [US3] Implement multi-language iteration loop in `TmdbMatcher.ResolveAsync`: iterate through `query.SearchLanguages ?? ["en-US"]`, search TMDB with `query.Title + language`, check/update deduplication cache, and return on first match — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
-- [ ] T025 [US3] Implement FallbackTitle retry in `TmdbMatcher.ResolveAsync`: after primary title exhausts all languages, retry with `query.FallbackTitle` (if non-null and different from Title) using the same language sequence — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
-- [ ] T026 [US3] Update `ScanPipeline` to populate `FallbackTitle` (from `EpisodeNameParseResult.FolderTitle`, only if different from `Title`) and `SearchLanguages` (from `LibraryRoot.SearchLanguages` or global default) in `MatchQuery` construction — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
-  > ⚠️ **F2 fix**: Set `FallbackTitle = folderTitle != parsedTitle ? folderTitle : null` — never set FallbackTitle equal to Title, or the matcher will issue a duplicate TMDB call with no benefit.
-- [ ] T027 [US3] Read `Scanner:DefaultSearchLanguages` from configuration and pass as fallback when `LibraryRoot.SearchLanguages` is null — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
+- [X] T023 [US3] Replace `LruCache<(string, int?, MediaType?), TmdbMatchResult>` with `ConcurrentDictionary<(string title, string language, int? year, MediaType? kind), TmdbMatchResult>` in `TmdbMatcher` — use the full tuple key to avoid cache collisions between queries with same title+language but different year or media type — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+- [X] T024 [US3] Implement multi-language iteration loop in `TmdbMatcher.ResolveAsync`: iterate through `query.SearchLanguages ?? ["en-US"]`, search TMDB with `query.Title + language`, check/update deduplication cache, and return on first match — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+- [X] T025 [US3] Implement FallbackTitle retry in `TmdbMatcher.ResolveAsync`: after primary title exhausts all languages, retry with `query.FallbackTitle` (if non-null and different from Title) using the same language sequence — in `MediaHandler.Infrastructure/Nas/Scanner/TmdbMatcher.cs`
+- [X] T026 [US3] Update `ScanPipeline` to populate `FallbackTitle` (from `EpisodeNameParseResult.FolderTitle`, only if different from `Title`) and `SearchLanguages` (from `LibraryRoot.SearchLanguages` or global default) in `MatchQuery` construction — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
+- [X] T027 [US3] Read `Scanner:DefaultSearchLanguages` from configuration and pass as fallback when `LibraryRoot.SearchLanguages` is null — in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs`
 
 **Checkpoint**: TMDB matcher now tries multiple languages and the folder-derived fallback title before routing to review. French titles like "Une Nounou Denfer" match via `fr-FR` search.
 


### PR DESCRIPTION
This pull request adds support for improved TV episode title parsing and flexible language configuration for TMDB searches. It introduces new configuration options for release tag patterns and search languages, extends the parsing models to capture more metadata, and updates the database schema to store per-library language preferences.

**Configuration and Options Enhancements:**

* Adds a new `Scanner` section in `appsettings.json` with `ReleaseTags` and `DefaultSearchLanguages` settings, allowing runtime configuration of release tag patterns and default search languages.
* Introduces the `ReleaseTagOptions` class, enabling injection and dynamic reloading of release tag regex patterns for cleaner episode title parsing. [[1]](diffhunk://#diff-e218c9aae09ded644be2afff3d891edf8d06f1e711089905f974028a56c17154R1-R28) [[2]](diffhunk://#diff-d9594c82948b2aeeab2275d8dc8fdb0ebe24d4686baa35c6a2ed24fc4d1e3cd3R3) [[3]](diffhunk://#diff-d9594c82948b2aeeab2275d8dc8fdb0ebe24d4686baa35c6a2ed24fc4d1e3cd3R52-R56)
* Updates `.specify/feature.json` and `.github/copilot-instructions.md` to reference the new feature directory and plan. [[1]](diffhunk://#diff-f5317a02f6ff349cdecbb91b03b28a062b4aafa952fd19df5b82083988e8c623L2-R2) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L9-R9)

**TV Episode Parsing Improvements:**

* Extends `EpisodeNameParseResult` to include `EpisodeTitle` (title after SxxExx marker) and `FolderTitle` (show title inferred from folder hierarchy), improving accuracy and fallback handling for episode identification.
* Updates `KodiNameParser` to accept optional `IOptionsMonitor<ReleaseTagOptions>`, merging custom patterns with built-in defaults for more robust title cleaning. [[1]](diffhunk://#diff-03c9f0e55542b765b0f4770b2fa137fa3bfe219bd5621f5fa275d59cfc8ea7c5R10-R21) [[2]](diffhunk://#diff-03c9f0e55542b765b0f4770b2fa137fa3bfe219bd5621f5fa275d59cfc8ea7c5L32-R52)

**TMDB Search Language Flexibility:**

* Adds `FallbackTitle` and `SearchLanguages` to `MatchQuery`, allowing TMDB lookups to retry with alternate titles and a prioritized list of languages.
* Updates `LibraryRoot` entity to store an ordered list of language tags for TMDB searches, enabling per-library language overrides.
* Adds a database migration and model snapshot update to persist `SearchLanguages` in the `LibraryRoots` table. [[1]](diffhunk://#diff-25d9fac6fa531127b023a22eaea3d4a90b4f5666c8df692ac8bb0e89a2a260f4R1-R29) [[2]](diffhunk://#diff-f381c384fdb1eac37034d79979a2f334333d5e48c7c8ab5493c2101d7dcbc25cR141-R144)

**Other Improvements:**

* Configures controllers to serialize enums as strings in JSON responses for better API clarity.
* Adds a missing package reference for `Microsoft.EntityFrameworkCore.Design` to support database migrations.