### PR TITLE
feat(admin-dashboard): enrichment and several adjustments

### DIFF
--- a/MediaHandler.API/Contracts/Admin/DashboardRequests.cs
+++ b/MediaHandler.API/Contracts/Admin/DashboardRequests.cs
@@ -7,7 +7,7 @@ namespace MediaHandler.API.Contracts.Admin;
 /// </summary>
 public record ReassignTmdbRequest(
     int TmdbId,
-    MediaType MediaType);
+    MediaType Kind);
 
 /// <summary>
 ///     Request body for <c>PUT /api/v1/admin/tv-groups/{groupId}/assign</c>.

--- a/MediaHandler.API/Contracts/Admin/ReviewRequests.cs
+++ b/MediaHandler.API/Contracts/Admin/ReviewRequests.cs
@@ -19,3 +19,16 @@ public record ResolveReviewRequest(
     int? TmdbId,
     /// <summary>Required when <see cref="Action"/> is <see cref="ReviewResolutionAction.Assign"/>.</summary>
     MediaType? Kind);
+
+/// <summary>
+///     Request body for <c>POST /api/v1/admin/review-items/bulk-resolve</c>.
+/// </summary>
+public record BulkResolveReviewRequest(
+    /// <summary>Absolute parent folder path — all Open review items under this path will be resolved.</summary>
+    string ParentFolderPath,
+    /// <summary>Resolution action to apply to every matched item.</summary>
+    ReviewResolutionAction Action,
+    /// <summary>Required when <see cref="Action"/> is <see cref="ReviewResolutionAction.Assign"/>.</summary>
+    int? TmdbId,
+    /// <summary>Required when <see cref="Action"/> is <see cref="ReviewResolutionAction.Assign"/>.</summary>
+    MediaType? Kind);

--- a/MediaHandler.API/Controllers/AdminEnrichmentController.cs
+++ b/MediaHandler.API/Controllers/AdminEnrichmentController.cs
@@ -1,7 +1,11 @@
 using MediaHandler.API.Contracts.Admin;
 using MediaHandler.API.Models;
 using MediaHandler.Application.Features.Dashboard.Commands.StartEnrichment;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Application.Features.Dashboard.Queries.GetEnrichmentRunDetails;
 using MediaHandler.Application.Features.Dashboard.Queries.GetEnrichmentStatus;
+using MediaHandler.Application.Features.Dashboard.Queries.GetEnrichmentSummary;
+using MediaHandler.Application.Features.Dashboard.Queries.ListEnrichmentHistory;
 using MediaHandler.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -83,6 +87,82 @@ public class AdminEnrichmentController(ISender sender) : ControllerBase
         }
 
         return Ok(ApiResponse<object>.Success(result.Value!));
+    }
+
+    /// <summary>
+    ///     Returns a pre-flight summary of how many media entries would be processed by a new enrichment run:
+    ///     new (never enriched), changed (updated since last run), skipped (already up-to-date), and total eligible.
+    /// </summary>
+    [HttpGet("summary")]
+    [ProducesResponseType<ApiResponse<EnrichmentSummaryDto>>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetEnrichmentSummary(CancellationToken ct)
+    {
+        var result = await sender.Send(new GetEnrichmentSummaryQuery(), ct);
+
+        if (!result.IsSuccess)
+        {
+            var error = result.Errors.FirstOrDefault() ?? "Unknown error";
+            return BadRequest(ApiResponse.Fail(new ApiError("QUERY_ERROR", error)));
+        }
+
+        return Ok(ApiResponse<EnrichmentSummaryDto>.Success(result.Value));
+    }
+
+    /// <summary>
+    ///     Returns a paginated list of past enrichment runs, ordered by most recent first.
+    /// </summary>
+    [HttpGet("history")]
+    [ProducesResponseType<ApiResponse<IReadOnlyList<EnrichmentRunDto>>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> ListEnrichmentHistory(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var pagedResult = await sender.Send(new ListEnrichmentHistoryQuery(page, pageSize), ct);
+
+        var meta = new ApiResponseMeta(
+            pagedResult.Page,
+            pagedResult.PageSize,
+            pagedResult.TotalCount,
+            pagedResult.TotalPages);
+
+        return Ok(ApiResponse<IReadOnlyList<EnrichmentRunDto>>.Success(pagedResult.Items, meta));
+    }
+
+    /// <summary>
+    ///     Returns a detailed per-media breakdown for a specific enrichment run.
+    ///     Lists every media entry processed, its outcome (Enriched / Failed / Skipped),
+    ///     associated file names, and any error message for failed entries.
+    /// </summary>
+    [HttpGet("{runId:guid}/details")]
+    [ProducesResponseType<ApiResponse<List<EnrichmentMediaDetailDto>>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetEnrichmentRunDetails(
+        Guid runId,
+        CancellationToken ct)
+    {
+        var result = await sender.Send(new GetEnrichmentRunDetailsQuery(runId), ct);
+
+        if (!result.IsSuccess)
+        {
+            var error = result.Errors.FirstOrDefault() ?? "Unknown error";
+
+            if (error.StartsWith("ENRICHMENT_RUN_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+                return NotFound(ApiResponse.Fail(
+                    new ApiError("ENRICHMENT_RUN_NOT_FOUND", $"Enrichment run '{runId}' was not found.")));
+
+            return BadRequest(ApiResponse.Fail(new ApiError("QUERY_ERROR", error)));
+        }
+
+        return Ok(ApiResponse<List<EnrichmentMediaDetailDto>>.Success(result.Value));
     }
 }
 

--- a/MediaHandler.API/Controllers/AdminParentFoldersController.cs
+++ b/MediaHandler.API/Controllers/AdminParentFoldersController.cs
@@ -1,0 +1,101 @@
+using MediaHandler.API.Models;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.Commands.AssignParentFolder;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Application.Features.Dashboard.Queries.ListParentFolders;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace MediaHandler.API.Controllers;
+
+/// <summary>
+///     Admin endpoints for browsing and assigning TMDB entries to NAS parent folders.
+///     All endpoints require the <c>AdminOnly</c> policy.
+/// </summary>
+[ApiController]
+[Route("api/v1/admin/parent-folders")]
+[Authorize(Policy = "AdminOnly")]
+[EnableRateLimiting("fixed")]
+public class AdminParentFoldersController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    ///     List unique NAS parent folders aggregated from media file paths.
+    ///     Supports optional filtering by <c>status</c> (NotAssigned, Assigned, InCollection).
+    ///     Paginated with <c>page</c> and <c>pageSize</c> (max 100).
+    /// </summary>
+    [HttpGet("")]
+    [ProducesResponseType<ApiResponse<IReadOnlyList<ParentFolderGroupDto>>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> ListParentFolders(
+        [FromQuery] string? status = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var query = new ListParentFoldersQuery(status, page, pageSize);
+        var pagedResult = await sender.Send(query, ct);
+
+        var meta = new ApiResponseMeta(
+            pagedResult.Page,
+            pagedResult.PageSize,
+            pagedResult.TotalCount,
+            pagedResult.TotalPages);
+
+        return Ok(ApiResponse<IReadOnlyList<ParentFolderGroupDto>>.Success(pagedResult.Items, meta));
+    }
+
+    /// <summary>
+    ///     Assign a TMDB entry to all media files inside the specified parent folder.
+    ///     Updates all linked <c>ScanItemDecision</c> records and <c>MediaFile.MediaId</c>.
+    /// </summary>
+    /// <param name="folderId">Deterministic folder GUID (SHA-256 of lower-invariant folder path).</param>
+    /// <param name="request">TMDB assignment details.</param>
+    /// <param name="ct">Cancellation token.</param>
+    [HttpPut("{folderId:guid}/assign")]
+    [ProducesResponseType<ApiResponse<ParentFolderGroupDto>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> AssignParentFolder(
+        Guid folderId,
+        [FromBody] AssignParentFolderRequest request,
+        CancellationToken ct = default)
+    {
+        var command = new AssignParentFolderCommand(folderId, request.FolderPath, request.TmdbId, request.Kind);
+        var result = await sender.Send(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            var error = result.Errors.FirstOrDefault() ?? "Unknown error";
+
+            if (error.Contains("FOLDER_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+                return NotFound(ApiResponse.Fail(new ApiError("FOLDER_NOT_FOUND",
+                    $"No media files found under '{request.FolderPath}'.")));
+
+            if (error.Contains("TMDB_ID_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+                return UnprocessableEntity(ApiResponse.Fail(new ApiError("TMDB_ID_NOT_FOUND",
+                    $"The TMDB id {request.TmdbId} does not correspond to a known movie or TV show.")));
+
+            return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR", error)));
+        }
+
+        return Ok(ApiResponse<ParentFolderGroupDto>.Success(result.Value));
+    }
+}
+
+/// <summary>Request body for <c>PUT /api/v1/admin/parent-folders/{folderId}/assign</c>.</summary>
+public record AssignParentFolderRequest(
+    /// <summary>Absolute path of the parent folder on the NAS.</summary>
+    string FolderPath,
+    /// <summary>TMDB id of the entry to assign.</summary>
+    int TmdbId,
+    /// <summary>Media type — Film or TvShow.</summary>
+    MediaType Kind);
+

--- a/MediaHandler.API/Controllers/AdminReviewController.cs
+++ b/MediaHandler.API/Controllers/AdminReviewController.cs
@@ -4,6 +4,7 @@
 using MediaHandler.API.Contracts.Admin;
 using MediaHandler.API.Models;
 using MediaHandler.Application.Common.DTOs;
+using MediaHandler.Application.Features.Review.Commands.BulkResolveReviewItems;
 using MediaHandler.Application.Features.Review.Commands.ResolveReviewItem;
 using MediaHandler.Application.Features.Review.Queries.ListReviewItems;
 using MediaHandler.Domain.Enums;
@@ -107,5 +108,41 @@ public class AdminReviewController(ISender sender) : ControllerBase
         }
 
         return Ok(ApiResponse<ReviewItemDto>.Success(result.Value));
+    }
+
+    /// <summary>
+    ///     Resolve all Open review items whose file path is inside <paramref name="request" />'s
+    ///     <c>ParentFolderPath</c>, applying the same action to every matched item in one call.
+    /// </summary>
+    [HttpPost("bulk-resolve")]
+    [ProducesResponseType<ApiResponse<BulkResolveResult>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> BulkResolveReviewItems(
+        [FromBody] BulkResolveReviewRequest request,
+        CancellationToken ct = default)
+    {
+        var command = new BulkResolveReviewItemsCommand(
+            request.ParentFolderPath,
+            request.Action,
+            request.TmdbId,
+            request.Kind);
+
+        var result = await sender.Send(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            var error = result.Errors.FirstOrDefault() ?? "Unknown error";
+
+            if (error.Contains("TMDB_ID_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+                return UnprocessableEntity(ApiResponse.Fail(new ApiError("TMDB_ID_NOT_FOUND",
+                    $"The TMDB id {request.TmdbId} does not correspond to a known movie or TV show.")));
+
+            return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR", error)));
+        }
+
+        return Ok(ApiResponse<BulkResolveResult>.Success(result.Value));
     }
 }

--- a/MediaHandler.API/Controllers/AdminScanController.cs
+++ b/MediaHandler.API/Controllers/AdminScanController.cs
@@ -4,6 +4,7 @@ using MediaHandler.Application.Common.DTOs;
 using MediaHandler.Application.Common.Models;
 using MediaHandler.Application.Features.Dashboard.DTOs;
 using MediaHandler.Application.Features.Dashboard.Queries.ListScanDecisions;
+using MediaHandler.Application.Features.Dashboard.Queries.ListGroupedScanDecisions;
 using MediaHandler.Application.Features.Scan.Commands.CancelScan;
 using MediaHandler.Application.Features.Scan.Commands.StartScan;
 using MediaHandler.Application.Features.Scan.Queries.GetActiveScan;
@@ -209,6 +210,36 @@ public class AdminScanController(ISender sender) : ControllerBase
             pagedResult.TotalCount,
             pagedResult.TotalPages);
 
-        return Ok(ApiResponse<PagedResult<ScanItemDecisionDto>>.Success(pagedResult, meta));
+        // Return the items array directly in `data` (matching the frontend contract),
+        // pagination info is carried by `meta`.
+        return Ok(ApiResponse<IReadOnlyList<ScanItemDecisionDto>>.Success(pagedResult.Items, meta));
+    }
+
+    /// <summary>
+    ///     Browse all <c>ScanItemDecision</c> records for a scan run, grouped by TV show.
+    ///     TV show episodes are deduplicated by file path and collapsed under a show-level header.
+    ///     Movie decisions remain as single-item groups.
+    ///     Supports the same filters as the flat <c>decisions</c> endpoint.
+    /// </summary>
+    [HttpGet("{scanId:guid}/decisions/grouped")]
+    [ProducesResponseType<ApiResponse<List<ScanDecisionShowGroupDto>>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ApiResponse>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> ListGroupedDecisions(
+        Guid scanId,
+        [FromQuery] ScanDecisionKind? decisionType = null,
+        [FromQuery] MediaType? mediaType = null,
+        [FromQuery] Guid? libraryRootId = null,
+        CancellationToken ct = default)
+    {
+        var result = await sender.Send(
+            new ListGroupedScanDecisionsQuery(scanId, decisionType, mediaType, libraryRootId), ct);
+
+        if (!result.IsSuccess)
+            return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR",
+                result.Errors.FirstOrDefault() ?? "Invalid query parameters.")));
+
+        return Ok(ApiResponse<List<ScanDecisionShowGroupDto>>.Success(result.Value));
     }
 }

--- a/MediaHandler.API/Controllers/AdminScanDecisionsController.cs
+++ b/MediaHandler.API/Controllers/AdminScanDecisionsController.cs
@@ -39,7 +39,7 @@ public class AdminScanDecisionsController(ISender sender) : ControllerBase
         CancellationToken ct)
     {
         var result = await sender.Send(
-            new ReassignTmdbCommand(id, request.TmdbId, request.MediaType), ct);
+            new ReassignTmdbCommand(id, request.TmdbId, request.Kind), ct);
 
         if (!result.IsSuccess)
         {

--- a/MediaHandler.Application/Common/DTOs/BulkResolveResult.cs
+++ b/MediaHandler.Application/Common/DTOs/BulkResolveResult.cs
@@ -1,0 +1,9 @@
+namespace MediaHandler.Application.Common.DTOs;
+
+/// <summary>
+///     Result returned by the bulk review-item resolution endpoint.
+/// </summary>
+public record BulkResolveResult(
+    /// <summary>Number of <c>ReviewItem</c> rows that were resolved in this operation.</summary>
+    int ResolvedCount);
+

--- a/MediaHandler.Application/Common/Interfaces/ITmdbService.cs
+++ b/MediaHandler.Application/Common/Interfaces/ITmdbService.cs
@@ -28,7 +28,7 @@ public record TmdbSearchCandidate(
 public interface ITmdbService
 {
     // Legacy search (used by existing TMDB import features)
-    Task<TmdbMediaDto?> SearchMediaAsync(string query, string language, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TmdbMediaDto>> SearchMediaAsync(string query, string language, CancellationToken cancellationToken = default);
 
     Task<TmdbMediaDetailsDto?> GetMediaDetailsAsync(int tmdbId, string mediaType, string language,
         CancellationToken cancellationToken = default);

--- a/MediaHandler.Application/Features/Dashboard/Commands/AssignParentFolder/AssignParentFolderCommand.cs
+++ b/MediaHandler.Application/Features/Dashboard/Commands/AssignParentFolder/AssignParentFolderCommand.cs
@@ -1,0 +1,133 @@
+using FluentValidation;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Application.Features.Dashboard.Queries.ListParentFolders;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using MediaEntity = MediaHandler.Domain.Entities.Media;
+
+namespace MediaHandler.Application.Features.Dashboard.Commands.AssignParentFolder;
+
+/// <summary>
+///     Assigns a TMDB entry to all media files located inside <see cref="FolderPath" />.
+///     Updates <c>ScanItemDecision.AssignedTmdbId/Kind</c> and <c>MediaFile.MediaId</c>
+///     for every file in the folder.
+/// </summary>
+public record AssignParentFolderCommand(
+    Guid FolderId,
+    string FolderPath,
+    int TmdbId,
+    MediaType Kind) : IRequest<Result<ParentFolderGroupDto>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class AssignParentFolderCommandValidator : AbstractValidator<AssignParentFolderCommand>
+{
+    public AssignParentFolderCommandValidator()
+    {
+        RuleFor(x => x.FolderPath).NotEmpty().WithMessage("FolderPath is required.");
+        RuleFor(x => x.TmdbId).GreaterThan(0).WithMessage("TmdbId must be a positive integer.");
+        RuleFor(x => x.Kind).IsInEnum().WithMessage("Kind must be Film or TvShow.");
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+public sealed class AssignParentFolderCommandHandler(
+    IApplicationDbContext db,
+    ITmdbService tmdbService)
+    : IRequestHandler<AssignParentFolderCommand, Result<ParentFolderGroupDto>>
+{
+    public async Task<Result<ParentFolderGroupDto>> Handle(
+        AssignParentFolderCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Verify TMDB entry exists
+        var lookup = request.Kind == MediaType.Film
+            ? await tmdbService.GetMovieByIdAsync(request.TmdbId, cancellationToken: cancellationToken)
+            : await tmdbService.GetTvShowByIdAsync(request.TmdbId, cancellationToken: cancellationToken);
+
+        if (lookup is null)
+            lookup = request.Kind == MediaType.Film
+                ? await tmdbService.GetTvShowByIdAsync(request.TmdbId, cancellationToken: cancellationToken)
+                : await tmdbService.GetMovieByIdAsync(request.TmdbId, cancellationToken: cancellationToken);
+
+        if (lookup is null)
+            return Result.Fail<ParentFolderGroupDto>(
+                $"TMDB_ID_NOT_FOUND: The TMDB id {request.TmdbId} does not correspond to a known movie or TV show.");
+
+        var folder = request.FolderPath.TrimEnd('/', '\\');
+
+        // Load all MediaFiles under this folder
+        var mediaFiles = await db.MediaFiles
+            .Where(f => f.FilePath.StartsWith(folder + "/") || f.FilePath.StartsWith(folder + "\\"))
+            .Include(f => f.Media)
+            .ToListAsync(cancellationToken);
+
+        if (mediaFiles.Count == 0)
+            return Result.Fail<ParentFolderGroupDto>(
+                $"FOLDER_NOT_FOUND: No media files found under '{request.FolderPath}'.");
+
+        // Upsert the Media row
+        var media = await db.Medias
+            .FirstOrDefaultAsync(m => m.TmdbId == lookup.TmdbId && m.Type == lookup.Kind, cancellationToken);
+
+        if (media is null)
+        {
+            media = new MediaEntity
+            {
+                TmdbId = lookup.TmdbId,
+                Title = lookup.Title,
+                Type = lookup.Kind,
+                Year = lookup.Year,
+                PosterPath = lookup.PosterPath
+            };
+            db.Medias.Add(media);
+            await db.SaveChangesAsync(cancellationToken); // Flush to get the new Media.Id
+        }
+
+        // Load linked ScanItemDecisions for these files
+        var fileIds = mediaFiles.Select(f => f.Id).ToList();
+        var decisions = await db.ScanItemDecisions
+            .Where(d => d.MediaFileId != null && fileIds.Contains(d.MediaFileId!.Value))
+            .ToListAsync(cancellationToken);
+
+        // Bulk-update decisions
+        foreach (var decision in decisions)
+        {
+            decision.AssignedTmdbId = lookup.TmdbId;
+            decision.AssignedTmdbKind = lookup.Kind;
+        }
+
+        // Link MediaFiles to the Media row
+        foreach (var mf in mediaFiles)
+            mf.MediaId = media.Id;
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        var dto = new ParentFolderGroupDto(
+            request.FolderId,
+            request.FolderPath,
+            GetLastSegment(folder),
+            mediaFiles.Count,
+            "Assigned",
+            lookup.TmdbId,
+            lookup.Title);
+
+        return Result.Success(dto);
+    }
+
+    private static string GetLastSegment(string folderPath)
+    {
+        var normalized = folderPath.TrimEnd('/').Replace('\\', '/');
+        var lastSlash = normalized.LastIndexOf('/');
+        return lastSlash >= 0 ? normalized[(lastSlash + 1)..] : normalized;
+    }
+}
+

--- a/MediaHandler.Application/Features/Dashboard/Commands/AssignTvGroup/AssignTvGroupCommand.cs
+++ b/MediaHandler.Application/Features/Dashboard/Commands/AssignTvGroup/AssignTvGroupCommand.cs
@@ -3,6 +3,7 @@
 // Resolves group members by recomputing the deterministic GroupId for every ParsedTitle group,
 // verifies the TMDB ID via ITmdbService, bulk-updates AssignedTmdbId/Kind on all member
 // decisions, and updates the linked MediaFile.MediaId for each.
+// T058 fix: tracks old MediaIds and removes orphaned Media rows when no files remain.
 
 using FluentValidation;
 using MediaHandler.Application.Common.Interfaces;
@@ -60,8 +61,10 @@ public class AssignTvGroupCommandValidator : AbstractValidator<AssignTvGroupComm
 ///         <item>Resolves group members by recomputing <c>GroupId = SHA256(scanId|parsedTitle.ToLower())</c>.</item>
 ///         <item>Returns failure if no decisions match the requested <paramref name="GroupId" />.</item>
 ///         <item>Verifies the TMDB id via <see cref="ITmdbService" />.</item>
-///         <item>Upserts the <c>Media</c> row and updates <c>AssignedTmdbId</c>/<c>AssignedTmdbKind</c> on all decisions.</item>
+///         <item>Looks up an existing <c>Media</c> row for the new TMDB ID, or creates one.</item>
+///         <item>Updates <c>AssignedTmdbId</c>/<c>AssignedTmdbKind</c> on all decisions.</item>
 ///         <item>Updates <c>MediaFile.MediaId</c> for every linked media file.</item>
+///         <item>Removes old <c>Media</c> rows that become orphaned (no remaining <c>MediaFile</c> references).</item>
 ///         <item>Saves all changes atomically.</item>
 ///     </list>
 /// </summary>
@@ -93,6 +96,13 @@ public sealed class AssignTvGroupCommandHandler(
 
         var parsedShowName = matchingDecisions[0].ParsedTitle!;
 
+        // Track old MediaIds (distinct) for orphan cleanup after the assignment
+        var oldMediaIds = matchingDecisions
+            .Where(d => d.MediaFile?.MediaId.HasValue == true)
+            .Select(d => d.MediaFile!.MediaId!.Value)
+            .Distinct()
+            .ToList();
+
         // Verify the TMDB id exists as a TV show
         var lookup = await tmdbService.GetTvShowByIdAsync(request.TmdbId, cancellationToken: cancellationToken);
 
@@ -121,6 +131,8 @@ public sealed class AssignTvGroupCommandHandler(
             await db.SaveChangesAsync(cancellationToken);
         }
 
+        var newMediaId = media.Id;
+
         // Bulk-update all member decisions
         foreach (var decision in matchingDecisions)
         {
@@ -128,10 +140,33 @@ public sealed class AssignTvGroupCommandHandler(
             decision.AssignedTmdbKind = lookup.Kind;
 
             if (decision.MediaFile is not null)
-                decision.MediaFile.MediaId = media.Id;
+                decision.MediaFile.MediaId = newMediaId;
         }
 
         await db.SaveChangesAsync(cancellationToken);
+
+        // Orphan cleanup: for each old Media row that is now no longer the new target,
+        // check if any MediaFile still references it; if not, remove the orphaned row.
+        var hadOrphans = false;
+        foreach (var oldMediaId in oldMediaIds.Where(id => id != newMediaId))
+        {
+            var hasRemainingFiles = await db.MediaFiles
+                .AnyAsync(f => f.MediaId == oldMediaId, cancellationToken);
+
+            if (!hasRemainingFiles)
+            {
+                var oldMedia = await db.Medias.FindAsync([oldMediaId], cancellationToken);
+                if (oldMedia is not null)
+                {
+                    db.Medias.Remove(oldMedia);
+                    hadOrphans = true;
+                }
+            }
+        }
+
+        // Persist orphan deletions in a single final save (if any)
+        if (hadOrphans)
+            await db.SaveChangesAsync(cancellationToken);
 
         return Result.Success(new AssignTvGroupResult(
             request.GroupId,

--- a/MediaHandler.Application/Features/Dashboard/Commands/ReassignTmdb/ReassignTmdbCommand.cs
+++ b/MediaHandler.Application/Features/Dashboard/Commands/ReassignTmdb/ReassignTmdbCommand.cs
@@ -1,6 +1,7 @@
 // ReassignTmdb — command, validator, and handler for correcting a TMDB match on a ScanItemDecision.
 // Loads the decision, verifies the TMDB id via ITmdbService, updates AssignedTmdbId/Kind,
 // updates the linked MediaFile.MediaId to point to the correct Media row, and saves.
+// T057 fix: tracks old MediaId and removes orphaned Media rows when no files remain.
 
 using FluentValidation;
 using MediaHandler.Application.Common.Interfaces;
@@ -56,7 +57,9 @@ public class ReassignTmdbCommandValidator : AbstractValidator<ReassignTmdbComman
 ///         <item>Loads the <c>ScanItemDecision</c>; returns failure if not found.</item>
 ///         <item>Verifies the TMDB id exists via <see cref="ITmdbService" />.</item>
 ///         <item>Updates <c>AssignedTmdbId</c> and <c>AssignedTmdbKind</c> on the decision.</item>
-///         <item>Upserts the linked <c>Media</c> row (TmdbId + Type) and points <c>MediaFile.MediaId</c> at it.</item>
+///         <item>Looks up an existing <c>Media</c> row for the new TMDB ID, or creates one.</item>
+///         <item>Updates <c>MediaFile.MediaId</c> to point at the new/existing <c>Media</c> row.</item>
+///         <item>Removes the old <c>Media</c> row if it becomes orphaned (no remaining <c>MediaFile</c> references).</item>
 ///         <item>Saves all changes atomically.</item>
 ///     </list>
 /// </summary>
@@ -78,21 +81,22 @@ public sealed class ReassignTmdbCommandHandler(
             return Result.Fail<ReassignTmdbResult>(
                 $"DECISION_NOT_FOUND: ScanItemDecision '{request.DecisionId}' was not found.");
 
-        // Verify the TMDB id actually exists — try hinted kind first, then the other
+        // Track the old MediaId before making any changes, for orphan cleanup later
+        var oldMediaId = decision.MediaFile?.MediaId;
+
+        // Verify the TMDB id exists for the EXACT requested media type.
+        // IMPORTANT: TMDB movie IDs and TV show IDs are independent namespaces — the same numeric
+        // ID can point to completely different entries in each namespace. Never fall back to the
+        // other type: doing so would silently assign a wrong film when the TV endpoint returns null.
         var lookup = request.MediaType == MediaType.Film
             ? await tmdbService.GetMovieByIdAsync(request.TmdbId, cancellationToken: cancellationToken)
             : await tmdbService.GetTvShowByIdAsync(request.TmdbId, cancellationToken: cancellationToken);
 
         if (lookup is null)
-            lookup = request.MediaType == MediaType.Film
-                ? await tmdbService.GetTvShowByIdAsync(request.TmdbId, cancellationToken: cancellationToken)
-                : await tmdbService.GetMovieByIdAsync(request.TmdbId, cancellationToken: cancellationToken);
-
-        if (lookup is null)
             return Result.Fail<ReassignTmdbResult>(
-                $"TMDB_ID_NOT_FOUND: The TMDB id {request.TmdbId} does not correspond to a known movie or TV show.");
+                $"TMDB_ID_NOT_FOUND: The TMDB id {request.TmdbId} does not correspond to a known {request.MediaType}.");
 
-        // Update the decision
+        // Update the decision assignment fields
         decision.AssignedTmdbId = lookup.TmdbId;
         decision.AssignedTmdbKind = lookup.Kind;
 
@@ -100,6 +104,7 @@ public sealed class ReassignTmdbCommandHandler(
         Guid? linkedMediaId = null;
         if (decision.MediaFile is not null)
         {
+            // Look up existing Media row for the new TMDB ID — reuse if found, create new if not
             var media = await db.Medias
                 .FirstOrDefaultAsync(
                     m => m.TmdbId == lookup.TmdbId && m.Type == lookup.Kind,
@@ -116,21 +121,35 @@ public sealed class ReassignTmdbCommandHandler(
                     PosterPath = lookup.PosterPath
                 };
                 db.Medias.Add(media);
-            }
-            else
-            {
-                linkedMediaId = media.Id;
+                // Save immediately so the Media.Id is persisted before linking MediaFile.
+                // This also reduces the race-condition window when multiple reassign calls
+                // arrive concurrently for the same TmdbId (though TV groups should use
+                // the AssignTvGroup batch endpoint instead to avoid N parallel inserts).
+                await db.SaveChangesAsync(cancellationToken);
             }
 
-            // For newly added Media, EF resolves the Id after SaveChanges
-            decision.MediaFile.MediaId = media.Id == Guid.Empty ? null : media.Id;
+            linkedMediaId = media.Id;
+            decision.MediaFile.MediaId = media.Id;
         }
 
         await db.SaveChangesAsync(cancellationToken);
 
-        // After save, the Media id is fully resolved (handles newly inserted rows)
-        if (decision.MediaFile?.MediaId is not null)
-            linkedMediaId = decision.MediaFile.MediaId;
+        // Orphan cleanup: if the old Media row has no remaining MediaFile references, remove it.
+        // This prevents stale enrichment data from accumulating when files are reassigned.
+        if (oldMediaId.HasValue && oldMediaId != linkedMediaId)
+        {
+            var hasRemainingFiles = await db.MediaFiles
+                .AnyAsync(f => f.MediaId == oldMediaId.Value, cancellationToken);
+
+            if (!hasRemainingFiles)
+            {
+                var oldMedia = await db.Medias.FindAsync([oldMediaId.Value], cancellationToken);
+                if (oldMedia is not null)
+                    db.Medias.Remove(oldMedia);
+
+                await db.SaveChangesAsync(cancellationToken);
+            }
+        }
 
         return Result.Success(new ReassignTmdbResult(
             decision.Id,

--- a/MediaHandler.Application/Features/Dashboard/DTOs/EnrichmentMediaDetailDto.cs
+++ b/MediaHandler.Application/Features/Dashboard/DTOs/EnrichmentMediaDetailDto.cs
@@ -1,0 +1,24 @@
+namespace MediaHandler.Application.Features.Dashboard.DTOs;
+
+/// <summary>
+///     Per-media entry detail for an enrichment run, returned by
+///     <c>GET /api/v1/admin/enrichment/{runId}/details</c>.
+/// </summary>
+/// <param name="MediaId">The internal media row identifier.</param>
+/// <param name="TmdbId">TMDB identifier of the media entry.</param>
+/// <param name="Title">Title of the media entry at the time of enrichment.</param>
+/// <param name="Type">Media type: <c>Film</c> or <c>TvShow</c>.</param>
+/// <param name="Status">Processing outcome: <c>Enriched</c>, <c>Failed</c>, or <c>Skipped</c>.</param>
+/// <param name="FileCount">Number of media files associated with this entry.</param>
+/// <param name="FileNames">List of file names associated with this entry.</param>
+/// <param name="Error">Error message when <paramref name="Status" /> is <c>Failed</c>; otherwise <c>null</c>.</param>
+public record EnrichmentMediaDetailDto(
+    Guid MediaId,
+    int? TmdbId,
+    string? Title,
+    string Type,
+    string Status,
+    int FileCount,
+    IReadOnlyList<string> FileNames,
+    string? Error);
+

--- a/MediaHandler.Application/Features/Dashboard/DTOs/EnrichmentSummaryDto.cs
+++ b/MediaHandler.Application/Features/Dashboard/DTOs/EnrichmentSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace MediaHandler.Application.Features.Dashboard.DTOs;
+
+/// <summary>
+///     Pre-flight summary showing how many media entries would be processed by an enrichment run.
+/// </summary>
+public record EnrichmentSummaryDto(
+    int NewCount,
+    int ChangedCount,
+    int SkippedCount,
+    int TotalEligible);

--- a/MediaHandler.Application/Features/Dashboard/DTOs/ParentFolderGroupDto.cs
+++ b/MediaHandler.Application/Features/Dashboard/DTOs/ParentFolderGroupDto.cs
@@ -1,0 +1,29 @@
+namespace MediaHandler.Application.Features.Dashboard.DTOs;
+
+/// <summary>
+///     Represents a unique NAS parent folder aggregated from <c>MediaFile.FilePath</c>,
+///     with its TMDB assignment status.
+/// </summary>
+public record ParentFolderGroupDto(
+    /// <summary>Deterministic SHA-256 GUID derived from <see cref="FolderPath" /> (lower-invariant).</summary>
+    Guid Id,
+    /// <summary>Absolute path of the parent directory on the NAS.</summary>
+    string FolderPath,
+    /// <summary>Inferred show name from the last path segment.</summary>
+    string DetectedShowName,
+    /// <summary>Number of media files located directly inside this folder.</summary>
+    int EpisodeCount,
+    /// <summary>
+    ///     Assignment status:
+    ///     <list type="bullet">
+    ///         <item><c>NotAssigned</c> — no TMDB assignment on any file in the folder.</item>
+    ///         <item><c>Assigned</c> — TMDB assigned via <c>ScanItemDecision</c> but not yet enriched into the Media collection.</item>
+    ///         <item><c>InCollection</c> — the linked <c>Media</c> row already has full TMDB metadata.</item>
+    ///     </list>
+    /// </summary>
+    string Status,
+    /// <summary>TMDB id of the assigned entry, when status is Assigned or InCollection.</summary>
+    int? TmdbId,
+    /// <summary>Title of the assigned TMDB entry.</summary>
+    string? TmdbTitle);
+

--- a/MediaHandler.Application/Features/Dashboard/DTOs/ScanDecisionShowGroupDto.cs
+++ b/MediaHandler.Application/Features/Dashboard/DTOs/ScanDecisionShowGroupDto.cs
@@ -1,0 +1,29 @@
+namespace MediaHandler.Application.Features.Dashboard.DTOs;
+
+/// <summary>
+///     A show-level group of scan decisions, with the episodes collapsed under a single header.
+///     Used by the grouped scan decisions endpoint.
+/// </summary>
+public record ScanDecisionShowGroupDto(
+    /// <summary>
+    ///     Deterministic group ID computed as SHA-256(scanId|parsedTitle.ToLower()) with UUID-v5 bits.
+    ///     Null for single-item (movie) pseudo-groups.
+    /// </summary>
+    Guid? GroupId,
+    /// <summary>Normalized show name used as the group key.</summary>
+    string ShowName,
+    /// <summary>Number of episode decisions in this group.</summary>
+    int EpisodeCount,
+    /// <summary>TMDB id assigned to the majority of episodes (null if not assigned).</summary>
+    int? AssignedTmdbId,
+    /// <summary>TMDB kind (Film/TvShow) assigned to the majority of episodes.</summary>
+    string? AssignedKind,
+    /// <summary>Title from the TMDB assignment (majority).</summary>
+    string? AssignedTitle,
+    /// <summary>Year from the TMDB assignment (majority).</summary>
+    int? AssignedYear,
+    /// <summary>Poster path from the TMDB assignment (majority).</summary>
+    string? AssignedPosterPath,
+    /// <summary>All individual episode decisions collapsed under this group.</summary>
+    IReadOnlyList<ScanItemDecisionDto> Episodes);
+

--- a/MediaHandler.Application/Features/Dashboard/DTOs/ScanItemDecisionDto.cs
+++ b/MediaHandler.Application/Features/Dashboard/DTOs/ScanItemDecisionDto.cs
@@ -1,3 +1,4 @@
+using MediaHandler.Application.Common.DTOs;
 using MediaHandler.Domain.Enums;
 
 namespace MediaHandler.Application.Features.Dashboard.DTOs;
@@ -5,30 +6,30 @@ namespace MediaHandler.Application.Features.Dashboard.DTOs;
 /// <summary>
 ///     Data-transfer object for a <see cref="MediaHandler.Domain.Entities.ScanItemDecision" /> row,
 ///     returned by the scan decisions browser API.
-///     <para>
-///         <c>assignedTitle</c>, <c>assignedYear</c>, and <c>assignedPosterPath</c> are resolved
-///         by joining <c>MediaFile → Media</c> in the query handler (not stored on the decision row).
-///         <c>libraryRootPath</c> is resolved from <c>LibraryRoot.Path</c>.
-///     </para>
+///     Field names are aligned with the Angular frontend contract (camelCase via default serialiser).
 /// </summary>
 public record ScanItemDecisionDto(
     Guid Id,
     Guid ScanRunId,
     string FilePath,
-    ScanDecisionKind Kind,
+    /// <summary>Outcome kind — serialised as <c>decisionType</c>.</summary>
+    ScanDecisionKind DecisionType,
     string? Reason,
     int? AssignedTmdbId,
-    MediaType? AssignedTmdbKind,
+    /// <summary>Media type of the TMDB assignment — serialised as <c>assignedKind</c>.</summary>
+    MediaType? AssignedKind,
     string? AssignedTitle,
     int? AssignedYear,
     string? AssignedPosterPath,
-    string? CandidatesJson,
+    /// <summary>Parsed TMDB candidates as a typed list (never null — empty list when absent).</summary>
+    IReadOnlyList<TmdbCandidateDto> Candidates,
     string? ParsedTitle,
     int? ParsedYear,
     int? ParsedSeason,
     int? ParsedEpisode,
-    MediaType? ParsedMediaType,
+    /// <summary>Media type inferred by the scanner — serialised as <c>mediaType</c>.</summary>
+    MediaType? MediaType,
     Guid? LibraryRootId,
-    string? LibraryRootPath,
-    Guid? MediaFileId);
-
+    Guid? MediaFileId,
+    /// <summary>Row creation timestamp — serialised as <c>decidedAt</c>.</summary>
+    DateTime DecidedAt);

--- a/MediaHandler.Application/Features/Dashboard/Queries/GetEnrichmentRunDetails/GetEnrichmentRunDetailsQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/GetEnrichmentRunDetails/GetEnrichmentRunDetailsQuery.cs
@@ -1,0 +1,142 @@
+// GetEnrichmentRunDetails — query and handler returning per-media enrichment details
+// for a specific enrichment run.
+//
+// Parses EnrichedMediaIdsJson from the EnrichmentRun row to rebuild the per-entry breakdown,
+// enriched with Media title/type and MediaFile names from the database.
+
+using System.Text.Json;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Dashboard.Queries.GetEnrichmentRunDetails;
+
+/// <summary>Query to retrieve per-media enrichment details for a specific run.</summary>
+public record GetEnrichmentRunDetailsQuery(Guid RunId)
+    : IRequest<Result<List<EnrichmentMediaDetailDto>>>;
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+/// <summary>
+///     Handles <see cref="GetEnrichmentRunDetailsQuery" />.
+///     <list type="bullet">
+///         <item>Loads the <c>EnrichmentRun</c> row by <c>RunId</c>.</item>
+///         <item>Parses <c>EnrichedMediaIdsJson</c> to recover per-media status entries.</item>
+///         <item>Batch-loads associated <c>Media</c> and <c>MediaFile</c> rows.</item>
+///         <item>Merges <c>ErrorDetailsJson</c> for the <c>error</c> field on failed entries.</item>
+///         <item>Returns a flat <c>List&lt;EnrichmentMediaDetailDto&gt;</c>.</item>
+///     </list>
+/// </summary>
+public sealed class GetEnrichmentRunDetailsQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<GetEnrichmentRunDetailsQuery, Result<List<EnrichmentMediaDetailDto>>>
+{
+    // Internal record mirroring the EnrichmentMediaResult persisted by EnrichmentCoordinator
+    private record MediaResultEntry(Guid MediaId, string Status);
+
+    public async Task<Result<List<EnrichmentMediaDetailDto>>> Handle(
+        GetEnrichmentRunDetailsQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Load the enrichment run
+        var run = await db.EnrichmentRuns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == request.RunId, cancellationToken);
+
+        if (run is null)
+            return Result.Fail<List<EnrichmentMediaDetailDto>>(
+                $"ENRICHMENT_RUN_NOT_FOUND: EnrichmentRun '{request.RunId}' was not found.");
+
+        // Parse per-media processing results
+        List<MediaResultEntry> mediaResults = [];
+        if (!string.IsNullOrEmpty(run.EnrichedMediaIdsJson))
+        {
+            try
+            {
+                mediaResults = JsonSerializer.Deserialize<List<MediaResultEntry>>(
+                    run.EnrichedMediaIdsJson,
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                    ?? [];
+            }
+            catch
+            {
+                mediaResults = [];
+            }
+        }
+
+        // Parse error details for failed entries (keyed by MediaId)
+        var errorsByMediaId = new Dictionary<Guid, string>();
+        if (!string.IsNullOrEmpty(run.ErrorDetailsJson))
+        {
+            try
+            {
+                var errors = JsonSerializer.Deserialize<List<EnrichmentErrorDetailDto>>(
+                    run.ErrorDetailsJson,
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                    ?? [];
+
+                foreach (var err in errors)
+                    errorsByMediaId[err.MediaId] = err.Error;
+            }
+            catch
+            {
+                // ignore — error detail is best-effort
+            }
+        }
+
+        if (mediaResults.Count == 0)
+            return Result.Success(new List<EnrichmentMediaDetailDto>());
+
+        // Batch-load all referenced Media rows
+        var mediaIds = mediaResults.Select(r => r.MediaId).Distinct().ToList();
+
+        var mediaLookup = await db.Medias
+            .AsNoTracking()
+            .Where(m => mediaIds.Contains(m.Id))
+            .Select(m => new { m.Id, m.TmdbId, m.Title, m.Type })
+            .ToDictionaryAsync(m => m.Id, cancellationToken);
+
+        // Batch-load all MediaFile rows for the referenced media entries
+        var filesByMediaId = await db.MediaFiles
+            .AsNoTracking()
+            .Where(f => f.MediaId != null && mediaIds.Contains(f.MediaId!.Value))
+            .GroupBy(f => f.MediaId!.Value)
+            .Select(g => new
+            {
+                MediaId = g.Key,
+                FileCount = g.Count(),
+                FileNames = g.Select(f => f.FilePath).ToList()
+            })
+            .ToDictionaryAsync(g => g.MediaId, cancellationToken);
+
+        // Build result
+        var details = mediaResults.Select(entry =>
+        {
+            mediaLookup.TryGetValue(entry.MediaId, out var media);
+            filesByMediaId.TryGetValue(entry.MediaId, out var files);
+            errorsByMediaId.TryGetValue(entry.MediaId, out var error);
+
+            var fileNames = files?.FileNames
+                .Select(path => System.IO.Path.GetFileName(path))
+                .ToList()
+                ?? [];
+
+            return new EnrichmentMediaDetailDto(
+                MediaId: entry.MediaId,
+                TmdbId: media?.TmdbId,
+                Title: media?.Title,
+                Type: media?.Type == MediaType.TvShow ? "TvShow" : "Film",
+                Status: entry.Status,
+                FileCount: files?.FileCount ?? 0,
+                FileNames: fileNames,
+                Error: error);
+        }).ToList();
+
+        return Result.Success(details);
+    }
+}
+

--- a/MediaHandler.Application/Features/Dashboard/Queries/GetEnrichmentSummary/GetEnrichmentSummaryQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/GetEnrichmentSummary/GetEnrichmentSummaryQuery.cs
@@ -1,0 +1,67 @@
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Dashboard.Queries.GetEnrichmentSummary;
+
+/// <summary>Query to retrieve a pre-flight enrichment summary.</summary>
+public record GetEnrichmentSummaryQuery : IRequest<Result<EnrichmentSummaryDto>>;
+
+/// <summary>
+///     Returns counts of media entries that would be processed by a new enrichment run:
+///     new (never enriched), changed (updated since last enrichment), and skipped (already up-to-date).
+/// </summary>
+public sealed class GetEnrichmentSummaryQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<GetEnrichmentSummaryQuery, Result<EnrichmentSummaryDto>>
+{
+    public async Task<Result<EnrichmentSummaryDto>> Handle(
+        GetEnrichmentSummaryQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Last completed enrichment timestamp
+        var lastFinishedAt = await db.EnrichmentRuns
+            .AsNoTracking()
+            .Where(r => r.Status == EnrichmentStatus.Completed && r.FinishedAt.HasValue)
+            .OrderByDescending(r => r.FinishedAt)
+            .Select(r => r.FinishedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // New: has a TMDB assignment but never enriched (Overview IS NULL)
+        var newCount = await db.Medias
+            .AsNoTracking()
+            .Where(m => m.TmdbId > 0 && m.Overview == null)
+            .CountAsync(cancellationToken);
+
+        // Changed: enriched before but updated since last enrichment
+        var changedCount = 0;
+        if (lastFinishedAt.HasValue)
+        {
+            changedCount = await db.Medias
+                .AsNoTracking()
+                .Where(m => m.TmdbId > 0
+                            && m.Overview != null
+                            && m.UpdatedAt > lastFinishedAt.Value)
+                .CountAsync(cancellationToken);
+        }
+
+        // Total media with TMDB assignment
+        var totalAssigned = await db.Medias
+            .AsNoTracking()
+            .Where(m => m.TmdbId > 0)
+            .CountAsync(cancellationToken);
+
+        var totalEligible = newCount + changedCount;
+        var skippedCount = totalAssigned - totalEligible;
+
+        return Result.Success(new EnrichmentSummaryDto(
+            NewCount: newCount,
+            ChangedCount: changedCount,
+            SkippedCount: skippedCount,
+            TotalEligible: totalEligible));
+    }
+}
+
+

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using FluentValidation;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Dashboard.Queries.ListEnrichmentHistory;
+
+/// <summary>
+///     Returns a paginated list of past enrichment runs, ordered by most recent first.
+/// </summary>
+public record ListEnrichmentHistoryQuery(
+    int Page,
+    int PageSize) : IRequest<PagedResult<EnrichmentRunDto>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class ListEnrichmentHistoryQueryValidator : AbstractValidator<ListEnrichmentHistoryQuery>
+{
+    public ListEnrichmentHistoryQueryValidator()
+    {
+        RuleFor(x => x.Page).GreaterThanOrEqualTo(1).WithMessage("page must be ≥ 1.");
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100).WithMessage("pageSize must be between 1 and 100.");
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+public sealed class ListEnrichmentHistoryQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<ListEnrichmentHistoryQuery, PagedResult<EnrichmentRunDto>>
+{
+    public async Task<PagedResult<EnrichmentRunDto>> Handle(
+        ListEnrichmentHistoryQuery request,
+        CancellationToken cancellationToken)
+    {
+        var query = db.EnrichmentRuns
+            .AsNoTracking()
+            .OrderByDescending(r => r.StartedAt);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var dtos = items.Select(r =>
+        {
+            IReadOnlyList<EnrichmentErrorDetailDto> errors = [];
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(r.ErrorDetailsJson) && r.ErrorDetailsJson != "[]")
+                    errors = JsonSerializer.Deserialize<List<EnrichmentErrorDetailDto>>(r.ErrorDetailsJson,
+                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+            }
+            catch
+            {
+                /* ignore malformed JSON */
+            }
+
+            return new EnrichmentRunDto(
+                r.Id,
+                r.Status,
+                r.StartedAt,
+                r.FinishedAt,
+                r.TotalItems,
+                r.EnrichedCount,
+                r.FailedCount,
+                r.SkippedCount,
+                r.CurrentItem,
+                errors);
+        }).ToList();
+
+        return new PagedResult<EnrichmentRunDto>(
+            dtos,
+            request.Page,
+            request.PageSize,
+            totalCount);
+    }
+}
+

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListGroupedScanDecisions/ListGroupedScanDecisionsQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListGroupedScanDecisions/ListGroupedScanDecisionsQuery.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentValidation;
+using MediaHandler.Application.Common.DTOs;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Dashboard.Queries.ListGroupedScanDecisions;
+
+/// <summary>
+///     Returns scan decisions for a given scan run, grouped by normalized <c>ParsedTitle</c>
+///     for TV show episodes. Movie decisions and ungroupable items remain as single-item groups.
+/// </summary>
+public record ListGroupedScanDecisionsQuery(
+    Guid ScanRunId,
+    ScanDecisionKind? DecisionType,
+    MediaType? MediaType,
+    Guid? LibraryRootId) : IRequest<Result<List<ScanDecisionShowGroupDto>>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class ListGroupedScanDecisionsQueryValidator : AbstractValidator<ListGroupedScanDecisionsQuery>
+{
+    public ListGroupedScanDecisionsQueryValidator()
+    {
+        RuleFor(x => x.ScanRunId).NotEmpty().WithMessage("ScanRunId is required.");
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+public sealed class ListGroupedScanDecisionsQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<ListGroupedScanDecisionsQuery, Result<List<ScanDecisionShowGroupDto>>>
+{
+    public async Task<Result<List<ScanDecisionShowGroupDto>>> Handle(
+        ListGroupedScanDecisionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var query = db.ScanItemDecisions
+            .AsNoTracking()
+            .Where(d => d.ScanRunId == request.ScanRunId);
+
+        if (request.DecisionType.HasValue)
+            query = query.Where(d => d.Kind == request.DecisionType.Value);
+
+        if (request.MediaType.HasValue)
+            query = query.Where(d => d.ParsedMediaType == request.MediaType.Value);
+
+        if (request.LibraryRootId.HasValue)
+            query = query.Where(d => d.LibraryRootId == request.LibraryRootId.Value);
+
+        var items = await query
+            .OrderBy(d => d.ParsedTitle).ThenBy(d => d.ParsedSeason).ThenBy(d => d.ParsedEpisode)
+            .Select(d => new
+            {
+                Decision = d,
+                MediaTitle = d.MediaFile != null && d.MediaFile.Media != null
+                    ? d.MediaFile.Media.Title
+                    : null,
+                MediaYear = d.MediaFile != null && d.MediaFile.Media != null
+                    ? d.MediaFile.Media.Year ?? (d.MediaFile.Media.ReleaseDate != null
+                        ? (int?)d.MediaFile.Media.ReleaseDate.Value.Year
+                        : null)
+                    : null,
+                MediaPosterPath = d.MediaFile != null && d.MediaFile.Media != null
+                    ? d.MediaFile.Media.PosterPath
+                    : null,
+            })
+            .ToListAsync(cancellationToken);
+
+        // Map to DTOs
+        var dtos = items.Select(x => new ScanItemDecisionDto(
+            x.Decision.Id,
+            x.Decision.ScanRunId,
+            x.Decision.FilePath,
+            x.Decision.Kind,
+            x.Decision.Reason,
+            x.Decision.AssignedTmdbId,
+            x.Decision.AssignedTmdbKind,
+            x.MediaTitle,
+            x.MediaYear,
+            x.MediaPosterPath,
+            ParseCandidates(x.Decision.CandidatesJson),
+            x.Decision.ParsedTitle,
+            x.Decision.ParsedYear,
+            x.Decision.ParsedSeason,
+            x.Decision.ParsedEpisode,
+            x.Decision.ParsedMediaType,
+            x.Decision.LibraryRootId,
+            x.Decision.MediaFileId,
+            x.Decision.CreatedAt
+        )).ToList();
+
+        // Deduplicate by FilePath (keep latest DecidedAt)
+        var deduped = dtos
+            .GroupBy(d => d.FilePath, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderByDescending(d => d.DecidedAt).First())
+            .ToList();
+
+        // Group TV episodes by normalized ParsedTitle; non-TV items stay as single-item groups
+        var groups = new List<ScanDecisionShowGroupDto>();
+
+        var tvItems = deduped.Where(d => d.MediaType == Domain.Enums.MediaType.TvShow && d.ParsedTitle != null).ToList();
+        var nonTvItems = deduped.Where(d => d.MediaType != Domain.Enums.MediaType.TvShow || d.ParsedTitle == null).ToList();
+
+        // Group TV by normalized title
+        var tvGroups = tvItems
+            .GroupBy(d => NormalizeTitle(d.ParsedTitle!), StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key);
+
+        foreach (var g in tvGroups)
+        {
+            var episodes = g.OrderBy(e => e.ParsedSeason).ThenBy(e => e.ParsedEpisode).ToList();
+
+            // Majority TMDB assignment from the group
+            var majorityAssignment = episodes
+                .Where(e => e.AssignedTmdbId.HasValue)
+                .GroupBy(e => e.AssignedTmdbId!.Value)
+                .OrderByDescending(ag => ag.Count())
+                .FirstOrDefault()
+                ?.First();
+
+            // Compute the deterministic GroupId used by AssignTvGroupCommand
+            var groupId = TvShowGroup.ComputeGroupId(request.ScanRunId, g.First().ParsedTitle!);
+
+            groups.Add(new ScanDecisionShowGroupDto(
+                groupId,
+                g.First().ParsedTitle!,
+                episodes.Count,
+                majorityAssignment?.AssignedTmdbId,
+                majorityAssignment?.AssignedKind?.ToString(),
+                majorityAssignment?.AssignedTitle,
+                majorityAssignment?.AssignedYear,
+                majorityAssignment?.AssignedPosterPath,
+                episodes));
+        }
+
+        // Non-TV items as individual groups
+        foreach (var item in nonTvItems.OrderBy(d => d.FilePath))
+        {
+            groups.Add(new ScanDecisionShowGroupDto(
+                null, // GroupId: not applicable for movie/single-item groups
+                item.ParsedTitle ?? Path.GetFileNameWithoutExtension(item.FilePath),
+                1,
+                item.AssignedTmdbId,
+                item.AssignedKind?.ToString(),
+                item.AssignedTitle,
+                item.AssignedYear,
+                item.AssignedPosterPath,
+                [item]));
+        }
+
+        return Result.Success(groups);
+    }
+
+    private static string NormalizeTitle(string title)
+    {
+        // Lowercase, trim, collapse whitespace
+        var normalized = title.Trim().ToLowerInvariant();
+        // Strip common language suffixes like " (en)", " (fr)", " - VF", " - VOSTFR"
+        normalized = System.Text.RegularExpressions.Regex.Replace(
+            normalized, @"\s*[\(\-]\s*(en|fr|vf|vostfr|multi|vo)\s*[\)]?\s*$", "",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return normalized;
+    }
+
+    private static IReadOnlyList<TmdbCandidateDto> ParseCandidates(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "[]")
+            return [];
+        try
+        {
+            var raw = JsonSerializer.Deserialize<List<CandidateJson>>(json);
+            return raw?.Select(c => new TmdbCandidateDto(
+                    c.TmdbId,
+                    Enum.Parse<Domain.Enums.MediaType>(c.Kind, true),
+                    c.Title,
+                    c.Year,
+                    c.Score,
+                    c.PosterPath))
+                .ToList() ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private record CandidateJson(
+        [property: JsonPropertyName("tmdbId")] int TmdbId,
+        [property: JsonPropertyName("kind")] string Kind,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("year")] int? Year,
+        [property: JsonPropertyName("score")] decimal Score,
+        [property: JsonPropertyName("posterPath")] string? PosterPath);
+}
+

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListParentFolders/ListParentFoldersQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListParentFolders/ListParentFoldersQuery.cs
@@ -1,0 +1,168 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentValidation;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Application.Features.Dashboard.DTOs;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Dashboard.Queries.ListParentFolders;
+
+/// <summary>
+///     Returns a paginated list of unique NAS parent folders aggregated from
+///     <c>MediaFile.FilePath</c>, with TMDB assignment status per folder.
+/// </summary>
+public record ListParentFoldersQuery(
+    string? Status,
+    int Page,
+    int PageSize) : IRequest<PagedResult<ParentFolderGroupDto>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class ListParentFoldersQueryValidator : AbstractValidator<ListParentFoldersQuery>
+{
+    private static readonly HashSet<string> AllowedStatuses =
+        new(["NotAssigned", "Assigned", "InCollection"], StringComparer.OrdinalIgnoreCase);
+
+    public ListParentFoldersQueryValidator()
+    {
+        RuleFor(x => x.Page).GreaterThanOrEqualTo(1).WithMessage("page must be ≥ 1.");
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100).WithMessage("pageSize must be between 1 and 100.");
+
+        When(x => x.Status is not null, () =>
+        {
+            RuleFor(x => x.Status)
+                .Must(s => AllowedStatuses.Contains(s!))
+                .WithMessage("status must be NotAssigned, Assigned, or InCollection.");
+        });
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+public sealed class ListParentFoldersQueryHandler(IApplicationDbContext db)
+    : IRequestHandler<ListParentFoldersQuery, PagedResult<ParentFolderGroupDto>>
+{
+    public async Task<PagedResult<ParentFolderGroupDto>> Handle(
+        ListParentFoldersQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Load all MediaFiles with related ScanItemDecision and Media to compute folder groups in memory.
+        // This is acceptable because the MediaFile table is bounded by the NAS library size.
+        var files = await db.MediaFiles
+            .AsNoTracking()
+            .Include(f => f.Media)
+            .ToListAsync(cancellationToken);
+
+        // Load ScanItemDecisions that reference those media files (latest per MediaFileId)
+        var mediaFileIds = files.Select(f => f.Id).ToHashSet();
+        var decisions = await db.ScanItemDecisions
+            .AsNoTracking()
+            .Where(d => d.MediaFileId != null && mediaFileIds.Contains(d.MediaFileId!.Value))
+            .ToListAsync(cancellationToken);
+
+        var decisionByFile = decisions
+            .GroupBy(d => d.MediaFileId!.Value)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(d => d.CreatedAt).First());
+
+        // Group files by parent directory
+        var groups = files
+            .GroupBy(f => GetParentFolder(f.FilePath))
+            .Where(g => !string.IsNullOrEmpty(g.Key))
+            .Select(g =>
+            {
+                var folderPath = g.Key;
+                var detectedShowName = GetLastSegment(folderPath);
+                var episodeCount = g.Count();
+
+                // Determine status from the most-enriched file in the group
+                string status = "NotAssigned";
+                int? tmdbId = null;
+                string? tmdbTitle = null;
+
+                // InCollection: any file links to a Media row with overview populated
+                var inCollection = g.FirstOrDefault(f =>
+                    f.MediaId.HasValue && f.Media?.Overview != null);
+                if (inCollection?.Media != null)
+                {
+                    status = "InCollection";
+                    tmdbId = inCollection.Media.TmdbId;
+                    tmdbTitle = inCollection.Media.Title;
+                }
+                else
+                {
+                    // Assigned: any linked ScanItemDecision has AssignedTmdbId
+                    var assigned = g
+                        .Where(f => decisionByFile.ContainsKey(f.Id))
+                        .Select(f => decisionByFile[f.Id])
+                        .FirstOrDefault(d => d.AssignedTmdbId.HasValue);
+
+                    if (assigned != null)
+                    {
+                        status = "Assigned";
+                        tmdbId = assigned.AssignedTmdbId;
+                    }
+                }
+
+                var folderId = ComputeFolderId(folderPath);
+
+                return new ParentFolderGroupDto(folderId, folderPath, detectedShowName, episodeCount, status,
+                    tmdbId, tmdbTitle);
+            })
+            .AsQueryable();
+
+        // Filter by status
+        if (!string.IsNullOrEmpty(request.Status))
+            groups = groups.Where(g =>
+                string.Equals(g.Status, request.Status, StringComparison.OrdinalIgnoreCase));
+
+        var ordered = groups.OrderBy(g => g.FolderPath).ToList();
+        var totalCount = ordered.Count;
+        var items = ordered
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .ToList();
+
+        return new PagedResult<ParentFolderGroupDto>(
+            items,
+            request.Page,
+            request.PageSize,
+            totalCount);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static string GetParentFolder(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath)) return string.Empty;
+
+        var normalized = filePath.Replace('\\', '/');
+        var lastSlash = normalized.LastIndexOf('/');
+        return lastSlash > 0 ? normalized[..lastSlash] : string.Empty;
+    }
+
+    private static string GetLastSegment(string folderPath)
+    {
+        var normalized = folderPath.TrimEnd('/').Replace('\\', '/');
+        var lastSlash = normalized.LastIndexOf('/');
+        return lastSlash >= 0 ? normalized[(lastSlash + 1)..] : normalized;
+    }
+
+    /// <summary>Deterministic GUID from SHA-256 of the lower-invariant folder path.</summary>
+    public static Guid ComputeFolderId(string folderPath)
+    {
+        var input = folderPath.ToLowerInvariant();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        hash[6] = (byte)((hash[6] & 0x0F) | 0x50); // version 5
+        hash[8] = (byte)((hash[8] & 0x3F) | 0x80); // variant RFC 4122
+        return new Guid(hash[..16]);
+    }
+}
+

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListScanDecisions/ListScanDecisionsQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListScanDecisions/ListScanDecisionsQuery.cs
@@ -3,7 +3,10 @@
 // joining MediaFile → Media to populate assignedTitle/Year/PosterPath,
 // and LibraryRoot to populate libraryRootPath.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentValidation;
+using MediaHandler.Application.Common.DTOs;
 using MediaHandler.Application.Common.Interfaces;
 using MediaHandler.Application.Common.Models;
 using MediaHandler.Application.Features.Dashboard.DTOs;
@@ -51,6 +54,7 @@ public class ListScanDecisionsQueryValidator : AbstractValidator<ListScanDecisio
 ///     Returns a paginated list of <see cref="ScanItemDecisionDto" />s for the requested scan run.
 ///     Joins <c>ScanItemDecision → MediaFile → Media</c> to resolve TMDB title/year/poster,
 ///     and <c>→ LibraryRoot</c> to resolve the library root path.
+///     Parses <c>CandidatesJson</c> into a typed <c>IReadOnlyList&lt;TmdbCandidateDto&gt;</c>.
 /// </summary>
 public sealed class ListScanDecisionsQueryHandler(IApplicationDbContext db)
     : IRequestHandler<ListScanDecisionsQuery, Result<PagedResult<ScanItemDecisionDto>>>
@@ -93,7 +97,6 @@ public sealed class ListScanDecisionsQueryHandler(IApplicationDbContext db)
                 MediaPosterPath = d.MediaFile != null && d.MediaFile.Media != null
                     ? d.MediaFile.Media.PosterPath
                     : null,
-                LibraryRootPath = d.LibraryRoot != null ? d.LibraryRoot.Path : null
             })
             .ToListAsync(cancellationToken);
 
@@ -101,22 +104,22 @@ public sealed class ListScanDecisionsQueryHandler(IApplicationDbContext db)
             x.Decision.Id,
             x.Decision.ScanRunId,
             x.Decision.FilePath,
-            x.Decision.Kind,
+            x.Decision.Kind,                 // → decisionType in JSON
             x.Decision.Reason,
             x.Decision.AssignedTmdbId,
-            x.Decision.AssignedTmdbKind,
+            x.Decision.AssignedTmdbKind,     // → assignedKind in JSON
             x.MediaTitle,
             x.MediaYear,
             x.MediaPosterPath,
-            x.Decision.CandidatesJson,
+            ParseCandidates(x.Decision.CandidatesJson),
             x.Decision.ParsedTitle,
             x.Decision.ParsedYear,
             x.Decision.ParsedSeason,
             x.Decision.ParsedEpisode,
-            x.Decision.ParsedMediaType,
+            x.Decision.ParsedMediaType,      // → mediaType in JSON
             x.Decision.LibraryRootId,
-            x.LibraryRootPath,
-            x.Decision.MediaFileId
+            x.Decision.MediaFileId,
+            x.Decision.CreatedAt             // → decidedAt in JSON
         )).ToList();
 
         return Result.Success(new PagedResult<ScanItemDecisionDto>(
@@ -125,5 +128,40 @@ public sealed class ListScanDecisionsQueryHandler(IApplicationDbContext db)
             request.Page,
             request.PageSize));
     }
-}
 
+    /// <summary>
+    ///     Deserialises the stored <c>CandidatesJson</c> string into a typed list.
+    ///     Returns an empty list on any parse failure so the API never crashes on malformed data.
+    /// </summary>
+    private static IReadOnlyList<TmdbCandidateDto> ParseCandidates(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "[]")
+            return [];
+
+        try
+        {
+            var raw = JsonSerializer.Deserialize<List<CandidateJson>>(json);
+            return raw?.Select(c => new TmdbCandidateDto(
+                    c.TmdbId,
+                    Enum.Parse<MediaType>(c.Kind, ignoreCase: true),
+                    c.Title,
+                    c.Year,
+                    c.Score,
+                    c.PosterPath))
+                .ToList() ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    // Private record used only for JSON deserialisation of CandidatesJson
+    private record CandidateJson(
+        [property: JsonPropertyName("tmdbId")] int TmdbId,
+        [property: JsonPropertyName("kind")] string Kind,
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("year")] int? Year,
+        [property: JsonPropertyName("score")] decimal Score,
+        [property: JsonPropertyName("posterPath")] string? PosterPath);
+}

--- a/MediaHandler.Application/Features/Review/Commands/BulkResolveReviewItems/BulkResolveReviewItemsCommand.cs
+++ b/MediaHandler.Application/Features/Review/Commands/BulkResolveReviewItems/BulkResolveReviewItemsCommand.cs
@@ -1,0 +1,145 @@
+using FluentValidation;
+using MediaHandler.Application.Common.DTOs;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Review.Commands.BulkResolveReviewItems;
+
+/// <summary>
+///     Resolves all Open <c>ReviewItem</c> rows whose <c>FilePath</c> starts with
+///     <see cref="ParentFolderPath" />, applying the same <see cref="Action" /> to every one.
+/// </summary>
+public record BulkResolveReviewItemsCommand(
+    string ParentFolderPath,
+    ReviewResolutionAction Action,
+    int? TmdbId,
+    MediaType? Kind) : IRequest<Result<BulkResolveResult>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class BulkResolveReviewItemsCommandValidator : AbstractValidator<BulkResolveReviewItemsCommand>
+{
+    public BulkResolveReviewItemsCommandValidator()
+    {
+        RuleFor(x => x.ParentFolderPath)
+            .NotEmpty().WithMessage("ParentFolderPath is required.");
+
+        RuleFor(x => x.Action)
+            .IsInEnum().WithMessage("Action must be Assign, Dismiss, or Delete.");
+
+        RuleFor(x => x.TmdbId)
+            .NotNull().WithMessage("TmdbId is required when Action is Assign.")
+            .When(x => x.Action == ReviewResolutionAction.Assign);
+
+        RuleFor(x => x.TmdbId)
+            .GreaterThan(0).WithMessage("TmdbId must be a positive integer.")
+            .When(x => x.Action == ReviewResolutionAction.Assign && x.TmdbId.HasValue);
+
+        RuleFor(x => x.Kind)
+            .NotNull().WithMessage("Kind is required when Action is Assign.")
+            .When(x => x.Action == ReviewResolutionAction.Assign);
+
+        RuleFor(x => x.Kind)
+            .IsInEnum().WithMessage("Kind must be Film or TvShow.")
+            .When(x => x.Action == ReviewResolutionAction.Assign && x.Kind.HasValue);
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+public sealed class BulkResolveReviewItemsCommandHandler(
+    IApplicationDbContext db,
+    ITmdbService tmdbService,
+    ICurrentUserService currentUser)
+    : IRequestHandler<BulkResolveReviewItemsCommand, Result<BulkResolveResult>>
+{
+    public async Task<Result<BulkResolveResult>> Handle(
+        BulkResolveReviewItemsCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Normalize folder path — ensure trailing separator so prefix match is safe
+        var folder = request.ParentFolderPath.TrimEnd('/', '\\');
+
+        // Load all Open ReviewItems under the folder (prefix match via EF Core)
+        var items = await db.ReviewItems
+            .Where(r => r.Status == ReviewStatus.Open
+                        && (r.FilePath.StartsWith(folder + "/") || r.FilePath.StartsWith(folder + "\\")))
+            .ToListAsync(cancellationToken);
+
+        if (items.Count == 0)
+            return Result.Success(new BulkResolveResult(0));
+
+        // For Assign — verify the TMDB id once before touching any rows
+        if (request.Action == ReviewResolutionAction.Assign)
+        {
+            var tmdbId = request.TmdbId!.Value;
+            var kind = request.Kind!.Value;
+
+            var lookup = kind == MediaType.Film
+                ? await tmdbService.GetMovieByIdAsync(tmdbId, cancellationToken: cancellationToken)
+                : await tmdbService.GetTvShowByIdAsync(tmdbId, cancellationToken: cancellationToken);
+
+            if (lookup is null)
+                lookup = kind == MediaType.Film
+                    ? await tmdbService.GetTvShowByIdAsync(tmdbId, cancellationToken: cancellationToken)
+                    : await tmdbService.GetMovieByIdAsync(tmdbId, cancellationToken: cancellationToken);
+
+            if (lookup is null)
+                return Result.Fail<BulkResolveResult>(
+                    $"TMDB_ID_NOT_FOUND: The TMDB id {tmdbId} does not correspond to a known movie or TV show.");
+        }
+
+        // Apply the action to every item
+        var resolvedAt = DateTime.UtcNow;
+        var resolvedBy = currentUser.OktaId;
+
+        foreach (var item in items)
+        {
+            switch (request.Action)
+            {
+                case ReviewResolutionAction.Assign:
+                    item.Status = ReviewStatus.Resolved;
+                    item.ResolvedTmdbId = request.TmdbId;
+                    item.ResolvedKind = request.Kind;
+                    item.ResolvedBy = resolvedBy;
+                    item.ResolvedAt = resolvedAt;
+                    break;
+
+                case ReviewResolutionAction.Dismiss:
+                    item.Status = ReviewStatus.Dismissed;
+                    item.ResolvedBy = resolvedBy;
+                    item.ResolvedAt = resolvedAt;
+                    break;
+
+                case ReviewResolutionAction.Delete:
+                    // Remove underlying MediaFile(s)
+                    var mediaFiles = await db.MediaFiles
+                        .Where(mf => mf.FilePath == item.FilePath)
+                        .ToListAsync(cancellationToken);
+
+                    if (mediaFiles.Count > 0)
+                        db.MediaFiles.RemoveRange(mediaFiles);
+
+                    item.Status = ReviewStatus.Dismissed;
+                    item.ResolvedBy = resolvedBy;
+                    item.ResolvedAt = resolvedAt;
+                    break;
+
+                default:
+                    return Result.Fail<BulkResolveResult>($"Unsupported bulk action: {request.Action}");
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(new BulkResolveResult(items.Count));
+    }
+}
+

--- a/MediaHandler.Application/Features/Tmdb/Queries/SearchTmdb/SearchTmdbQueryHandler.cs
+++ b/MediaHandler.Application/Features/Tmdb/Queries/SearchTmdb/SearchTmdbQueryHandler.cs
@@ -13,10 +13,7 @@ public class SearchTmdbQueryHandler(ITmdbService tmdb)
     public async Task<Result<IReadOnlyList<TmdbMediaDto>>> Handle(SearchTmdbQuery request,
         CancellationToken cancellationToken)
     {
-        var result = await tmdb.SearchMediaAsync(request.Query, request.Language ?? "en", cancellationToken);
-
-        return result is null
-            ? Result.Success<IReadOnlyList<TmdbMediaDto>>(Array.Empty<TmdbMediaDto>())
-            : Result.Success<IReadOnlyList<TmdbMediaDto>>(new[] { result });
+        var results = await tmdb.SearchMediaAsync(request.Query, request.Language ?? "en", cancellationToken);
+        return Result.Success<IReadOnlyList<TmdbMediaDto>>(results);
     }
 }

--- a/MediaHandler.Domain/Entities/EnrichmentRun.cs
+++ b/MediaHandler.Domain/Entities/EnrichmentRun.cs
@@ -49,5 +49,11 @@ public class EnrichmentRun : BaseEntity
     ///     Stored as <c>nvarchar(max)</c>; deserialized only when needed for reporting.
     /// </summary>
     public string? ErrorDetailsJson { get; set; }
-}
 
+    /// <summary>
+    ///     JSON array tracking per-media processing results for this run.
+    ///     Each element is <c>{ "MediaId": "guid", "Status": "Enriched|Failed|Skipped" }</c>.
+    ///     Stored as <c>nvarchar(max)</c>; used by the enrichment details endpoint.
+    /// </summary>
+    public string? EnrichedMediaIdsJson { get; set; }
+}

--- a/MediaHandler.Infrastructure/Migrations/20260510125446_AddEnrichedMediaIdsJson.Designer.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260510125446_AddEnrichedMediaIdsJson.Designer.cs
@@ -4,6 +4,7 @@ using MediaHandler.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MediaHandler.Infrastructure.Migrations
 {
     [DbContext(typeof(MediaHandlerDbContext))]
-    partial class MediaHandlerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510125446_AddEnrichedMediaIdsJson")]
+    partial class AddEnrichedMediaIdsJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MediaHandler.Infrastructure/Migrations/20260510125446_AddEnrichedMediaIdsJson.cs
+++ b/MediaHandler.Infrastructure/Migrations/20260510125446_AddEnrichedMediaIdsJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MediaHandler.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEnrichedMediaIdsJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EnrichedMediaIdsJson",
+                table: "EnrichmentRuns",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EnrichedMediaIdsJson",
+                table: "EnrichmentRuns");
+        }
+    }
+}

--- a/MediaHandler.Infrastructure/Persistence/Configurations/EnrichmentRunConfiguration.cs
+++ b/MediaHandler.Infrastructure/Persistence/Configurations/EnrichmentRunConfiguration.cs
@@ -26,6 +26,9 @@ public class EnrichmentRunConfiguration : IEntityTypeConfiguration<EnrichmentRun
         // ErrorDetailsJson stored as nvarchar(max) — no max length constraint
         builder.Property(r => r.ErrorDetailsJson);
 
+        // EnrichedMediaIdsJson stored as nvarchar(max) — no max length constraint
+        builder.Property(r => r.EnrichedMediaIdsJson);
+
         // Indexes
 
         builder.HasIndex(r => r.Status)
@@ -39,4 +42,3 @@ public class EnrichmentRunConfiguration : IEntityTypeConfiguration<EnrichmentRun
             .HasDatabaseName("UX_EnrichmentRuns_Running");
     }
 }
-

--- a/MediaHandler.Infrastructure/Services/EnrichmentCoordinator.cs
+++ b/MediaHandler.Infrastructure/Services/EnrichmentCoordinator.cs
@@ -7,6 +7,7 @@
 // Media field population (Title, Overview, Runtime, PosterPath, Status, genres, etc.)
 // TvSeason/TvEpisode upsert for TV shows
 // Per-entry error tracking + progress reporting every 10 entries or 5 seconds
+// T061: records per-media processing results in EnrichedMediaIdsJson
 
 using System.Text.Json;
 using MediaHandler.Application.Common.DTOs;
@@ -20,6 +21,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace MediaHandler.Infrastructure.Services;
+
+/// <summary>Lightweight record used to track per-media enrichment outcome in <c>EnrichedMediaIdsJson</c>.</summary>
+/// <param name="MediaId">The <c>Media</c> row identifier.</param>
+/// <param name="Status">Processing outcome: <c>Enriched</c>, <c>Failed</c>, or <c>Skipped</c>.</param>
+internal record EnrichmentMediaResult(Guid MediaId, string Status);
 
 /// <summary>
 ///     Singleton coordinator that owns the lifecycle of background batch TMDB enrichment runs.
@@ -122,6 +128,7 @@ public sealed class EnrichmentCoordinator : IEnrichmentCoordinator
 
             // Process each item
             var errors = new List<EnrichmentErrorDetailDto>();
+            var mediaResults = new List<EnrichmentMediaResult>();
             var enrichedCount = 0;
             var failedCount = 0;
             var lastSave = DateTime.UtcNow;
@@ -143,6 +150,7 @@ public sealed class EnrichmentCoordinator : IEnrichmentCoordinator
                         await UpsertTvSeasonsAsync(db, tmdbService, media);
 
                     enrichedCount++;
+                    mediaResults.Add(new EnrichmentMediaResult(media.Id, "Enriched"));
 
                     _logger.LogDebug(
                         "EnrichmentCoordinator: enriched media {MediaId} ({Title}).", media.Id, media.Title);
@@ -152,6 +160,7 @@ public sealed class EnrichmentCoordinator : IEnrichmentCoordinator
                     // Per-entry error tracking — do NOT abort the batch
                     failedCount++;
                     errors.Add(new EnrichmentErrorDetailDto(media.Id, media.TmdbId, media.Title, ex.Message));
+                    mediaResults.Add(new EnrichmentMediaResult(media.Id, "Failed"));
 
                     _logger.LogWarning(ex,
                         "EnrichmentCoordinator: failed to enrich media {MediaId} (TMDB {TmdbId}).",
@@ -167,6 +176,7 @@ public sealed class EnrichmentCoordinator : IEnrichmentCoordinator
                     run.EnrichedCount = enrichedCount;
                     run.FailedCount = failedCount;
                     run.ErrorDetailsJson = JsonSerializer.Serialize(errors);
+                    run.EnrichedMediaIdsJson = JsonSerializer.Serialize(mediaResults);
 
                     try
                     {
@@ -188,6 +198,7 @@ public sealed class EnrichmentCoordinator : IEnrichmentCoordinator
             run.FailedCount = failedCount;
             run.CurrentItem = null;
             run.ErrorDetailsJson = JsonSerializer.Serialize(errors);
+            run.EnrichedMediaIdsJson = JsonSerializer.Serialize(mediaResults);
 
             _logger.LogInformation(
                 "EnrichmentCoordinator: run {RunId} completed. Enriched={Enriched}, Failed={Failed}.",

--- a/MediaHandler.Infrastructure/Services/MediaAutoMatchService.cs
+++ b/MediaHandler.Infrastructure/Services/MediaAutoMatchService.cs
@@ -119,14 +119,14 @@ public sealed class MediaAutoMatchService(
                     ? $"{parsed.Title} {parsed.Year}"
                     : parsed.Title;
 
-                var searchResult = await tmdb.SearchMediaAsync(query, language, ct);
+                var searchResult = (await tmdb.SearchMediaAsync(query, language, ct)).FirstOrDefault();
                 await Task.Delay(TmdbDelayMs, ct); // respect rate limit after every call
 
                 if (searchResult is null && parsed.Year.HasValue)
                 {
                     logger.LogInformation(
                         "TMDB search with year found nothing for '{Query}'. Retrying without year.", query);
-                    searchResult = await tmdb.SearchMediaAsync(parsed.Title, language, ct);
+                    searchResult = (await tmdb.SearchMediaAsync(parsed.Title, language, ct)).FirstOrDefault();
                     await Task.Delay(TmdbDelayMs, ct);
                 }
 

--- a/MediaHandler.Infrastructure/Tmdb/TmdbService.cs
+++ b/MediaHandler.Infrastructure/Tmdb/TmdbService.cs
@@ -11,25 +11,29 @@ namespace MediaHandler.Infrastructure.Tmdb;
 public sealed class TmdbService(HttpClient httpClient, ILogger<TmdbService> logger)
     : ITmdbService
 {
-    public async Task<TmdbMediaDto?> SearchMediaAsync(string query, string language,
+    public async Task<IReadOnlyList<TmdbMediaDto>> SearchMediaAsync(string query, string language,
         CancellationToken cancellationToken = default)
     {
         var url = $"/3/search/multi?query={Uri.EscapeDataString(query)}&language={language}";
         var response =
             await httpClient.GetFromJsonAsync<TmdbPagedResponse<TmdbSearchResultJson>>(url, cancellationToken);
-        var first = response?.Results?.FirstOrDefault(r => r.MediaType is "movie" or "tv");
-        if (first is null) return null;
 
-        return new TmdbMediaDto(
-            first.Id,
-            first.Title ?? first.Name ?? string.Empty,
-            first.OriginalTitle ?? first.OriginalName,
-            first.Overview,
-            first.MediaType ?? "unknown",
-            ParseDate(first.ReleaseDate ?? first.FirstAirDate),
-            first.PosterPath,
-            first.BackdropPath,
-            (decimal?)first.VoteAverage);
+        if (response?.Results is null) return [];
+
+        return response.Results
+            .Where(r => r.MediaType is "movie" or "tv")
+            .Take(10)
+            .Select(r => new TmdbMediaDto(
+                r.Id,
+                r.Title ?? r.Name ?? string.Empty,
+                r.OriginalTitle ?? r.OriginalName,
+                r.Overview,
+                r.MediaType ?? "unknown",
+                ParseDate(r.ReleaseDate ?? r.FirstAirDate),
+                r.PosterPath,
+                r.BackdropPath,
+                (decimal?)r.VoteAverage))
+            .ToList();
     }
 
     public async Task<TmdbMediaDetailsDto?> GetMediaDetailsAsync(int tmdbId, string mediaType, string language,
@@ -234,11 +238,17 @@ public sealed class TmdbService(HttpClient httpClient, ILogger<TmdbService> logg
         if (response?.Results is null) return [];
 
         // Convert to TmdbSearchCandidate, apply type filter, then take top 5 by popularity
+        // IMPORTANT: /search/movie and /search/tv endpoints do NOT return a mediaType field in results.
+        // r.MediaType is only populated by /search/multi. When a kindHint is given we used a typed
+        // endpoint, so we must force the Kind from the hint rather than reading r.MediaType (which
+        // would be null, causing all TV-show results to be wrongly stored as MediaType.Film).
         var candidates = response.Results
-            .Where(r => r.MediaType is null or "movie" or "tv") // filter out "person"
+            .Where(r => r.MediaType is null or "movie" or "tv") // filter out "person" from multi-search
             .Select(r => new TmdbSearchCandidate(
                 r.Id,
-                r.MediaType == "tv" ? MediaType.TvShow : MediaType.Film,
+                kindHint.HasValue
+                    ? kindHint.Value                                         // typed endpoint → trust hint
+                    : (r.MediaType == "tv" ? MediaType.TvShow : MediaType.Film), // multi → read field
                 r.Title ?? r.Name ?? string.Empty,
                 ParseDate(r.ReleaseDate ?? r.FirstAirDate)?.Year,
                 (decimal)(r.Popularity ?? r.VoteAverage ?? 0),

--- a/MediaHandler.IntegrationTests/Features/Files/ScanAndImportIntegrationTests.cs
+++ b/MediaHandler.IntegrationTests/Features/Files/ScanAndImportIntegrationTests.cs
@@ -60,10 +60,10 @@ public class ScanAndImportIntegrationTests : IntegrationTestBase
         // Configure TMDB mock — search by query
         tmdb.SearchMediaAsync(Arg.Is<string>(q => q.Contains("Matrix")), Arg.Any<string>(),
                 Arg.Any<CancellationToken>())
-            .Returns(MatrixSearchResult);
+            .Returns(new List<TmdbMediaDto> { MatrixSearchResult });
         tmdb.SearchMediaAsync(Arg.Is<string>(q => q.Contains("Inception")), Arg.Any<string>(),
                 Arg.Any<CancellationToken>())
-            .Returns(InceptionSearchResult);
+            .Returns(new List<TmdbMediaDto> { InceptionSearchResult });
 
         // Configure TMDB details mock
         tmdb.GetMediaDetailsAsync(603, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())

--- a/MediaHandler.Tests/Features/Files/MediaAutoMatchServiceTests.cs
+++ b/MediaHandler.Tests/Features/Files/MediaAutoMatchServiceTests.cs
@@ -54,7 +54,7 @@ public class MediaAutoMatchServiceTests
             .Returns(new ParsedMediaInfo("The Matrix", 1999, "movie"));
 
         _tmdb.SearchMediaAsync("The Matrix 1999", "en", Arg.Any<CancellationToken>())
-            .Returns(MatrixSearchResult);
+            .Returns(new List<TmdbMediaDto> { MatrixSearchResult });
 
         _importer.ImportOrGetExistingAsync(603, "movie", "en", Arg.Any<CancellationToken>())
             .Returns(Result.Success(mediaId));
@@ -105,10 +105,10 @@ public class MediaAutoMatchServiceTests
             .Returns(new ParsedMediaInfo("Unknown Movie", 2099, null));
 
         _tmdb.SearchMediaAsync("Unknown Movie 2099", "en", Arg.Any<CancellationToken>())
-            .Returns((TmdbMediaDto?)null);
+            .Returns(new List<TmdbMediaDto>());
         // Fallback search without year also returns nothing
         _tmdb.SearchMediaAsync("Unknown Movie", "en", Arg.Any<CancellationToken>())
-            .Returns((TmdbMediaDto?)null);
+            .Returns(new List<TmdbMediaDto>());
 
         // Act
         var result = await _service.MatchAndLinkUnlinkedFilesAsync([file], "en", CancellationToken.None);
@@ -135,7 +135,7 @@ public class MediaAutoMatchServiceTests
             .Returns(new ParsedMediaInfo("The Matrix", 1999, "movie"));
 
         _tmdb.SearchMediaAsync("The Matrix 1999", "en", Arg.Any<CancellationToken>())
-            .Returns(MatrixSearchResult);
+            .Returns(new List<TmdbMediaDto> { MatrixSearchResult });
 
         _importer.ImportOrGetExistingAsync(603, "movie", "en", Arg.Any<CancellationToken>())
             .Returns(Result.Fail<Guid>("TMDB returned no details."));

--- a/specs/004-admin-dashboard-api/tasks.md
+++ b/specs/004-admin-dashboard-api/tasks.md
@@ -62,7 +62,7 @@
 
 ---
 
-## Phase 3: User Story 8 — ScanItemDecision Entity Enhancement (Priority: P1) 🎯 MVP
+## Phase 3: User Story 8 — ScanItemDecision Entity Enhancement (Priority: P1)  MVP
 
 **Goal**: Ensure the scan pipeline populates the new `ScanItemDecision` fields so downstream features have data to work with
 
@@ -202,122 +202,116 @@
 
 ---
 
-## Dependencies & Execution Order
+---
+
+## Phase 12: User Story 13 — Bulk Review Item Resolution by Parent Folder (Priority: P1)
+
+**Goal**: Resolve all open review items sharing the same parent folder path in a single operation
+
+**Independent Test**: Call `POST /api/v1/admin/review-items/bulk-resolve` with `{ parentFolderPath, action, tmdbId, kind }`, verify all Open ReviewItems under that folder path are resolved and `resolvedCount` is returned
+
+### Implementation for User Story 13
+
+- [x] T045 [US13] Create `BulkResolveReviewItemsCommand` record (`ParentFolderPath`, `Action`, `TmdbId?`, `Kind?`) with `BulkResolveReviewItemsCommandValidator` and `BulkResolveReviewItemsCommandHandler` (loads all Open `ReviewItem` rows where `FilePath` starts with `parentFolderPath`, applies same resolution action to each — mirrors single-item logic (Assign verifies TMDB via `ITmdbService`, Dismiss/Delete supported), returns `resolvedCount`) in MediaHandler.Application/Features/Review/Commands/BulkResolveReviewItems/BulkResolveReviewItemsCommand.cs
+- [x] T046 [US13] Add `POST /api/v1/admin/review-items/bulk-resolve` endpoint to `AdminReviewController`, accepting `BulkResolveReviewRequest` body (`ParentFolderPath`, `Action`, `TmdbId?`, `Kind?`), returning `ApiResponse<BulkResolveResult>` (`ResolvedCount`) in MediaHandler.API/Controllers/AdminReviewController.cs
+
+**Checkpoint**: Admins can resolve all sibling review items in a folder in one call.
+
+---
+
+## Phase 13: User Story 14 — Parent Folder TMDB Validation Endpoints (Priority: P2)
+
+**Goal**: Provide a paginated view of unique NAS parent folders aggregated from `MediaFile.FilePath`, with per-folder TMDB assignment status and an assign endpoint
+
+**Independent Test**: Call `GET /api/v1/admin/parent-folders`, verify folders are grouped by parent directory with correct `status` (`NotAssigned`/`Assigned`/`InCollection`), `episodeCount`, and `detectedShowName`. Call `PUT /api/v1/admin/parent-folders/{folderId}/assign` with a TMDB TV show ID, verify all `ScanItemDecision` records linked to media files in that folder get updated.
+
+### Implementation for User Story 14
+
+- [x] T047 [US14] [P] Create `ParentFolderGroupDto` record (`Id`, `FolderPath`, `DetectedShowName`, `EpisodeCount`, `Status` [enum string: `NotAssigned`/`Assigned`/`InCollection`], `TmdbId?`, `TmdbTitle?`) in MediaHandler.Application/Features/Dashboard/DTOs/ParentFolderGroupDto.cs
+- [x] T048 [US14] Create `ListParentFoldersQuery` record (`Status?`, `Page`, `PageSize`) with `ListParentFoldersQueryValidator` and `ListParentFoldersQueryHandler`: groups `MediaFile.FilePath` by parent directory (using `Path.GetDirectoryName`-equivalent string slicing on SQL), computes deterministic `Id = SHA256(folderPath.ToLowerInvariant())`, derives `DetectedShowName` from last path segment, counts `EpisodeCount`, determines `Status` from TMDB coverage (`InCollection` if any linked `Media.TmdbId` is non-null AND overview is populated; `Assigned` if `ScanItemDecision.AssignedTmdbId` is set; otherwise `NotAssigned`), returns paginated `ParentFolderGroupDto` list in MediaHandler.Application/Features/Dashboard/Queries/ListParentFolders/ListParentFoldersQuery.cs
+- [x] T049 [US14] Create `AssignParentFolderCommand` record (`FolderId`, `FolderPath`, `TmdbId`, `Kind`) with `AssignParentFolderCommandValidator` and `AssignParentFolderCommandHandler`: verifies TMDB via `ITmdbService`, finds all `MediaFile` rows whose `FilePath` starts with `FolderPath`, bulk-updates linked `ScanItemDecision.AssignedTmdbId`/`AssignedTmdbKind`, upserts `Media` row via `MediaImportService`, updates `MediaFile.MediaId`, returns updated `ParentFolderGroupDto` in MediaHandler.Application/Features/Dashboard/Commands/AssignParentFolder/AssignParentFolderCommand.cs
+- [x] T050 [US14] Create `AdminParentFoldersController` (`[Route("api/v1/admin/parent-folders")]`, `[Authorize(Policy = "AdminOnly")]`) with `GET /` (query params: `status?`, `page`, `pageSize`, returning `ApiResponse<PagedResult<ParentFolderGroupDto>>`) and `PUT /{folderId}/assign` (body: `AssignParentFolderRequest` with `FolderPath`, `TmdbId`, `Kind`, returning `ApiResponse<ParentFolderGroupDto>`) in MediaHandler.API/Controllers/AdminParentFoldersController.cs
+
+**Checkpoint**: Admins can view all TV show parent folders, filter by assignment status, and bulk-assign TMDB entries at the folder level.
+
+---
+
+## Phase 14: Frontend Support — Grouped Scan Decisions Endpoint (Priority: P2)
+
+**Goal**: Server-side TV show episode deduplication and grouping for the scan results browser. Eliminates need for client-side deduplication.
+
+### Implementation
+
+- [x] T051 [P] Create `ScanDecisionShowGroupDto` record (`ShowName`, `EpisodeCount`, `AssignedTmdbId`, `AssignedKind`, `AssignedTitle`, `AssignedYear`, `AssignedPosterPath`, `Episodes` list of `ScanItemDecisionDto`) in MediaHandler.Application/Features/Dashboard/DTOs/ScanDecisionShowGroupDto.cs
+- [x] T052 Create `ListGroupedScanDecisionsQuery` with handler — deduplicates by file path, groups TV episodes by normalized `ParsedTitle` (strips language suffixes), movies stay as single-item groups, majority TMDB assignment per group — in MediaHandler.Application/Features/Dashboard/Queries/ListGroupedScanDecisions/ListGroupedScanDecisionsQuery.cs
+- [x] T053 Add `GET /api/v1/admin/scan/{scanId}/decisions/grouped` endpoint to `AdminScanController`, accepting same filters as flat decisions endpoint, returning `ApiResponse<List<ScanDecisionShowGroupDto>>` in MediaHandler.API/Controllers/AdminScanController.cs
+
+**Checkpoint**: Frontend can call grouped endpoint instead of doing client-side deduplication.
+
+---
+
+## Phase 15: Frontend Support — Enrichment History Endpoint (Priority: P2)
+
+**Goal**: Paginated history of past enrichment runs for the enrichment page
+
+### Implementation
+
+- [x] T054 Create `ListEnrichmentHistoryQuery` with handler — paginated, ordered by `StartedAt` descending, deserializes `ErrorDetailsJson` into typed `EnrichmentErrorDetailDto` list — in MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs
+- [x] T055 Add `GET /api/v1/admin/enrichment/history` endpoint to `AdminEnrichmentController`, accepting `page` and `pageSize` query params, returning `ApiResponse<IReadOnlyList<EnrichmentRunDto>>` with pagination meta in MediaHandler.API/Controllers/AdminEnrichmentController.cs
+
+**Checkpoint**: Frontend can display paginated enrichment run history with error details.
+
+---
+
+## Phase 16: Issue Fix — Reassign TMDB for Already-Enriched Media (Priority: P1)
+
+**Goal**: Fix the reassign endpoint to correctly handle media entries that have already been enriched with full TMDB metadata. Currently reassigning an already-enriched media to a new TMDB ID may fail or leave stale data.
+
+**Independent Test**: Assign a media file to TMDB ID X, run enrichment (populating overview, genres, seasons, etc.), then call `PUT /api/v1/admin/scan-decisions/{id}/reassign` with TMDB ID Y — verify the decision's `AssignedTmdbId` is updated, the linked `MediaFile.MediaId` points to the new `Media` row (created or existing), and the old enrichment data is cleared or a re-enrichment is flagged.
+
+**Depends on**: Phase 5 (US2 - Reassignment Endpoint)
+
+### Implementation for Reassign Fix
+
+- [x] T056 [P] Investigate `ReassignTmdbCommandHandler` in MediaHandler.Application/Features/Dashboard/Commands/ReassignTmdb/ReassignTmdbCommand.cs — verify it handles the case where `MediaFile.MediaId` already points to an enriched `Media` entity. Check if: (a) the handler creates a new `Media` row or reuses an existing one for the new TMDB ID, (b) old `Media` row orphans are cleaned up if no other files reference it, (c) `Media.Overview` and related enrichment fields are cleared when TMDB ID changes to flag re-enrichment
+- [x] T057 Fix `ReassignTmdbCommandHandler` to correctly handle already-enriched media: (1) look up existing `Media` row for the new `tmdbId` — reuse if found, create new if not, (2) update `MediaFile.MediaId` to the new/existing `Media` row, (3) if the old `Media` row has no remaining `MediaFile` references, optionally mark it for cleanup, (4) update `ScanItemDecision` fields (`AssignedTmdbId`, `AssignedTmdbKind`, assigned title/year/poster from TMDB lookup) — modify MediaHandler.Application/Features/Dashboard/Commands/ReassignTmdb/ReassignTmdbCommand.cs
+- [x] T058 [P] Fix `AssignTvGroupCommandHandler` to apply the same enriched-media handling as T057 — when re-assigning a TV show group to a different TMDB ID, ensure all member `MediaFile` rows are updated and old orphan `Media` rows are handled — modify MediaHandler.Application/Features/Dashboard/Commands/AssignTvGroup/AssignTvGroupCommand.cs
+
+**Checkpoint**: Reassigning TMDB for already-enriched media works correctly; no orphan or stale data
+
+---
+
+## Phase 17: Issue Fix — Enrichment Per-Media Details Endpoint (Priority: P2)
+
+**Goal**: Provide a detailed breakdown of each enrichment run showing which media entries were enriched/failed/skipped, with their file names and counts
+
+**Independent Test**: Run an enrichment, call `GET /api/v1/admin/enrichment/{runId}/details` — verify response contains a list of per-media entries with `mediaId`, `tmdbId`, `title`, `type`, `status` (Enriched/Failed/Skipped), `fileCount`, `fileNames`, and `error` (for failed entries)
+
+**Depends on**: Phase 8 (US5 — Enrichment), Phase 15 (Enrichment History)
+
+### Implementation for Enrichment Per-Media Details
+
+- [x] T059 [P] Create `EnrichmentMediaDetailDto` record (`MediaId`, `TmdbId`, `Title`, `Type` [Film/TvShow], `Status` [Enriched/Failed/Skipped], `FileCount`, `FileNames` [list of string], `Error` [nullable]) in MediaHandler.Application/Features/Dashboard/DTOs/EnrichmentMediaDetailDto.cs
+- [x] T060 [P] Add `EnrichedMediaIdsJson` column to `EnrichmentRun` entity to track which media IDs were processed and their status during enrichment — modify MediaHandler.Domain/Entities/EnrichmentRun.cs. Add column mapping in MediaHandler.Infrastructure/Persistence/Configurations/EnrichmentRunConfiguration.cs. Generate migration.
+- [x] T061 Update `EnrichmentCoordinator` to record per-media processing results in `EnrichedMediaIdsJson` — for each media entry processed, append `{ mediaId, status }` to the JSON field. This enables the details endpoint to reconstruct what happened per media — modify MediaHandler.Infrastructure/Services/EnrichmentCoordinator.cs
+- [x] T062 Create `GetEnrichmentRunDetailsQuery` record (`RunId`) with handler: (1) load `EnrichmentRun` by ID, (2) parse `EnrichedMediaIdsJson` to get list of processed media IDs and statuses, (3) for each media ID, join to `Media` table (get title, tmdbId, type) and `MediaFile` table (get file count and file names), (4) merge with `ErrorDetailsJson` for failed entries, (5) return `List<EnrichmentMediaDetailDto>` — in MediaHandler.Application/Features/Dashboard/Queries/GetEnrichmentRunDetails/GetEnrichmentRunDetailsQuery.cs
+- [x] T063 Add `GET /api/v1/admin/enrichment/{runId}/details` endpoint to `AdminEnrichmentController`, returning `ApiResponse<List<EnrichmentMediaDetailDto>>` — modify MediaHandler.API/Controllers/AdminEnrichmentController.cs
+
+**Checkpoint**: Frontend can fetch detailed per-media breakdown for any enrichment run
+
+---
+
+## Dependencies & Execution Order (Issue Fixes — Phases 16–17)
 
 ### Phase Dependencies
 
-- **Setup (Phase 1)**: No dependencies — can start immediately
-- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
-- **US8 (Phase 3)**: Depends on Foundational — must complete before US1 (provides data for scan decisions browser)
-- **US1 (Phase 4)**: Depends on US8 (needs populated `ScanItemDecision` fields)
-- **US2 (Phase 5)**: Depends on Foundational — can run in parallel with US1
-- **US3 (Phase 6)**: Depends on Foundational — can run in parallel with US1/US2
-- **US4 (Phase 7)**: Depends on US3 (needs TV group computation logic)
-- **US5 (Phase 8)**: Depends on Foundational — can run in parallel with US1-US4
-- **US6 (Phase 9)**: Depends on Foundational — can run in parallel with US1-US5
-- **US7 (Phase 10)**: Depends on US3 (TV group resolution) and US6 (single-file rename service)
-- **Polish (Phase 11)**: Depends on all user stories being complete
-
-### User Story Dependencies
-
-- **US8 (P1)**: Foundational only — MUST complete first (provides data for all other stories)
-- **US1 (P1)**: Depends on US8 — scan decisions must have new fields populated
-- **US2 (P1)**: Foundational only — independently testable
-- **US3 (P2)**: Foundational only — independently testable
-- **US4 (P2)**: Depends on US3 — needs TV group computation
-- **US5 (P2)**: Foundational only — independently testable
-- **US6 (P3)**: Foundational only — independently testable
-- **US7 (P3)**: Depends on US3 + US6 — needs group resolution and rename service
-
-### Within Each User Story
-
-- Models/DTOs before services
-- Services before handlers
-- Handlers before controller endpoints
-- Core implementation before integration
+- **Phase 16 (Reassign Fix)**: Depends on Phase 5 (US2 — Reassignment endpoint must exist). Independent of Phase 17.
+- **Phase 17 (Enrichment Details)**: Depends on Phase 8 (US5 — Enrichment must exist) and Phase 15 (History endpoint). Independent of Phase 16.
 
 ### Parallel Opportunities
 
-- All Setup tasks marked [P] can run in parallel (T002, T003, T004 — entity changes in different files; T005, T006, T007 — configurations in different files)
-- All Foundational DTOs marked [P] can run in parallel (T010–T018)
-- After Foundational: US2, US3, US5, US6 can all start in parallel (no inter-story dependencies)
-- Within US5: T030 and T031 can be developed in parallel (command vs query)
+- **Phases 16 and 17 can run fully in parallel** — they touch different subsystems
+- T056, T058 (Phase 16 investigation + TV group fix) — parallel after T057
+- T059, T060 (Phase 17 DTO + entity change) — parallel
 
----
-
-## Parallel Example: After Foundational Phase
-
-```
-# These user stories can be worked on simultaneously by different developers:
-Developer A: US8 → US1 (scan pipeline + browser — critical path)
-Developer B: US2 + US5 (reassignment + enrichment — independent)
-Developer C: US3 → US4 (TV groups + group assignment — dependent pair)
-Developer D: US6 → US7 (single rename + batch rename — dependent pair)
-```
-
-## Parallel Example: Setup Phase
-
-```
-# Launch all entity changes together:
-Task T002: Add fields to ScanItemDecision entity
-Task T003: Add fields to Media entity
-Task T004: Create EnrichmentRun entity
-
-# Launch all EF configurations together (after entities):
-Task T005: Update ScanItemDecisionConfiguration
-Task T006: Create EnrichmentRunConfiguration
-Task T007: Update MediaConfiguration
-```
-
----
-
-## Implementation Strategy
-
-### MVP First (US8 + US1 + US2)
-
-1. Complete Phase 1: Setup (entity + migration changes)
-2. Complete Phase 2: Foundational (DTOs, interfaces, startup cleanup)
-3. Complete Phase 3: US8 (scan pipeline populates new fields)
-4. Complete Phase 4: US1 (scan results browser)
-5. Complete Phase 5: US2 (TMDB reassignment)
-6. **STOP and VALIDATE**: Test scan browser + reassignment end-to-end
-
-### Incremental Delivery
-
-1. Setup + Foundational → Data layer ready
-2. US8 → Scan pipeline enhanced → Re-scan to populate data
-3. US1 → Admins can browse scan decisions → Deploy/Demo (MVP!)
-4. US2 → Admins can fix wrong matches → Deploy/Demo
-5. US3 + US4 → TV show grouping + assignment → Deploy/Demo
-6. US5 → Batch enrichment → Deploy/Demo
-7. US6 + US7 → File renaming → Deploy/Demo
-8. Polish → Final validation → Release
-
-### Parallel Team Strategy
-
-With multiple developers:
-
-1. Team completes Setup + Foundational together
-2. Once Foundational is done:
-   - Developer A: US8 → US1 (critical path — data pipeline)
-   - Developer B: US2 (reassignment — independent)
-   - Developer C: US3 → US4 (TV groups — dependent pair)
-3. After US8 + US1 validated:
-   - Developer A: US5 (enrichment)
-   - Developer D: US6 → US7 (rename — dependent pair)
-4. Stories integrate independently via separate controllers (`AdminScanController`, `AdminScanDecisionsController`, `AdminEnrichmentController`, `AdminFilesController`)
-
----
-
-## Notes
-
-- [P] tasks = different files, no dependencies
-- [Story] label maps task to specific user story for traceability
-- Each user story should be independently completable and testable
-- New endpoints are spread across 3 new controllers + 1 modified (`AdminScanController`, `AdminScanDecisionsController`, `AdminEnrichmentController`, `AdminFilesController`) following SRP
-- Follow existing patterns: `ListScanHistoryQuery` for paginated queries, `ResolveReviewItemCommand` for commands, `ScanRunCoordinator` for background services
-- `TvShowGroup` is transient (computed at query time) — NO database table
-- `EnrichmentRun` IS persisted — dedicated table with concurrency lock
-- Commit after each task or logical group
-- Stop at any checkpoint to validate story independently
-
+````


### PR DESCRIPTION
This pull request introduces several new admin API endpoints and related backend features for bulk operations and improved data browsing, especially around parent folder assignments, enrichment runs, and review item resolution. It also refines some existing endpoints, improves validation, and fixes parameter naming for consistency.

**New admin endpoints and bulk operations:**

* Added `AdminParentFoldersController` with endpoints to list NAS parent folders and assign TMDB entries to all media files under a folder. This includes request/response models, validation, and handler logic for bulk assignment. [[1]](diffhunk://#diff-e4d3484342f67480f03da9e3c25909a8f0f19e0e3c8549ebc3ae594d092e5ce4R1-R101) [[2]](diffhunk://#diff-b779959c37d196ec5bac7f320183268214ba291c2607c8ee18b78aa22d76ab66R1-R133)
* Added a bulk review item resolution endpoint (`POST /api/v1/admin/review-items/bulk-resolve`) to resolve all open review items under a specified parent folder in one call, with a new result model. [[1]](diffhunk://#diff-830b1f71036e8e251d988b0468511409040f65792c6c6c111bbf8faf2c39f2acR112-R147) [[2]](diffhunk://#diff-8980fd02a39f83f29816830910bb05b7ae2e498e4cd4d25af93dce8721c0d741R22-R34) [[3]](diffhunk://#diff-8e52fa9262257e3dd7daf57f12dd56bf1c89e6cfcc49afceae999faba2371d26R1-R9)

**Enrichment run enhancements:**

* Added endpoints to get a summary of eligible media for enrichment, list past enrichment runs (with pagination), and fetch detailed results for a specific run.

**Scan decisions improvements:**

* Added an endpoint to group scan decisions by TV show, deduplicating episodes under a show header, and updated the flat list endpoint to return only the items array for frontend compatibility.

**Parameter consistency and interface changes:**

* Renamed `MediaType` to `Kind` in several request models and endpoints for consistency. [[1]](diffhunk://#diff-895feb9d0823aadcb2064a08a50d6d4c99528c34c129beb520a3f228be4dbbf1L10-R10) [[2]](diffhunk://#diff-24632d2572ad1acd06522319c8089318c2e3d8657f69aff8abcdab26ceb6675fL42-R42)
* Changed the TMDB search interface to return a list of candidates instead of a single result.

**Other improvements:**

* Added validation to the new commands and improved error handling for TMDB ID lookups and folder existence.
* Documented a fix for orphaned Media rows in TV group assignments.

**References:**
[[1]](diffhunk://#diff-e4d3484342f67480f03da9e3c25909a8f0f19e0e3c8549ebc3ae594d092e5ce4R1-R101) [[2]](diffhunk://#diff-b779959c37d196ec5bac7f320183268214ba291c2607c8ee18b78aa22d76ab66R1-R133) [[3]](diffhunk://#diff-830b1f71036e8e251d988b0468511409040f65792c6c6c111bbf8faf2c39f2acR112-R147) [[4]](diffhunk://#diff-8980fd02a39f83f29816830910bb05b7ae2e498e4cd4d25af93dce8721c0d741R22-R34) [[5]](diffhunk://#diff-8e52fa9262257e3dd7daf57f12dd56bf1c89e6cfcc49afceae999faba2371d26R1-R9) [[6]](diffhunk://#diff-0d2b9e0b2fb40e6f19467432a5fe0c04853375be4ce18dc0b84e77cc584b0807R91-R166) [[7]](diffhunk://#diff-dd49e70ea05ed70555fb394eeb1ef61d52837329175c673377b0c49c7d876d02L212-R243) [[8]](diffhunk://#diff-895feb9d0823aadcb2064a08a50d6d4c99528c34c129beb520a3f228be4dbbf1L10-R10) [[9]](diffhunk://#diff-24632d2572ad1acd06522319c8089318c2e3d8657f69aff8abcdab26ceb6675fL42-R42) [[10]](diffhunk://#diff-6dd541518e42d1d372c8434a8866ceb920aa209387b31a5daa5e54e09248351bL31-R31) [[11]](diffhunk://#diff-f6cd9b68be8f8501ea744658e6b2fbb7cd41e4985d1e499e332c56ff7f168c62R6)