### PR TITLE
Add sorting, filtering, and media query enhancements

### DIFF
--- a/MediaHandler.API/Contracts/Admin/ReviewRequests.cs
+++ b/MediaHandler.API/Contracts/Admin/ReviewRequests.cs
@@ -32,3 +32,12 @@ public record BulkResolveReviewRequest(
     int? TmdbId,
     /// <summary>Required when <see cref="Action"/> is <see cref="ReviewResolutionAction.Assign"/>.</summary>
     MediaType? Kind);
+
+/// <summary>
+///     Request body for <c>POST /api/v1/admin/review-items/batch-assign</c>.
+/// </summary>
+public record BatchAssignReviewItemsRequest(
+    /// <summary>IDs of the review items to assign.</summary>
+    Guid[] ReviewItemIds,
+    /// <summary>Internal Media.Id of the target media record.</summary>
+    Guid TargetMediaId);

--- a/MediaHandler.API/Controllers/AdminController.cs
+++ b/MediaHandler.API/Controllers/AdminController.cs
@@ -22,9 +22,10 @@ public class AdminController(ISender sender) : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetUsers([FromQuery] int page = 1, [FromQuery] int pageSize = 20,
-        [FromQuery] string? search = null, CancellationToken ct = default)
+        [FromQuery] string? search = null, [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc", CancellationToken ct = default)
     {
-        var result = await sender.Send(new GetUsersQuery(page, pageSize, search), ct);
+        var result = await sender.Send(new GetUsersQuery(page, pageSize, search, sortField, sortOrder), ct);
         var meta = new ApiResponseMeta(result.Value.Page, result.Value.PageSize, result.Value.TotalCount,
             result.Value.TotalPages);
         return Ok(ApiResponse<object>.Success(result.Value.Items, meta));

--- a/MediaHandler.API/Controllers/AdminEnrichmentController.cs
+++ b/MediaHandler.API/Controllers/AdminEnrichmentController.cs
@@ -123,9 +123,11 @@ public class AdminEnrichmentController(ISender sender) : ControllerBase
     public async Task<IActionResult> ListEnrichmentHistory(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 20,
+        [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc",
         CancellationToken ct = default)
     {
-        var pagedResult = await sender.Send(new ListEnrichmentHistoryQuery(page, pageSize), ct);
+        var pagedResult = await sender.Send(new ListEnrichmentHistoryQuery(page, pageSize, sortField, sortOrder), ct);
 
         var meta = new ApiResponseMeta(
             pagedResult.Page,

--- a/MediaHandler.API/Controllers/AdminLibraryRootsController.cs
+++ b/MediaHandler.API/Controllers/AdminLibraryRootsController.cs
@@ -36,9 +36,12 @@ public class AdminLibraryRootsController(ISender sender) : ControllerBase
         [FromQuery] int pageSize = 20,
         [FromQuery] LibraryRootKind? kind = null,
         [FromQuery] bool enabledOnly = false,
+        [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc",
+        [FromQuery] string? path = null,
         CancellationToken ct = default)
     {
-        var result = await sender.Send(new ListLibraryRootsQuery(page, pageSize, kind, enabledOnly), ct);
+        var result = await sender.Send(new ListLibraryRootsQuery(page, pageSize, kind, enabledOnly, sortField, sortOrder, path), ct);
 
         if (!result.IsSuccess)
             return BadRequest(ApiResponse.Fail(result.Errors.Select(e => new ApiError("BAD_REQUEST", e)).ToArray()));

--- a/MediaHandler.API/Controllers/AdminReviewController.cs
+++ b/MediaHandler.API/Controllers/AdminReviewController.cs
@@ -4,6 +4,7 @@
 using MediaHandler.API.Contracts.Admin;
 using MediaHandler.API.Models;
 using MediaHandler.Application.Common.DTOs;
+using MediaHandler.Application.Features.Review.Commands.BatchAssignReviewItems;
 using MediaHandler.Application.Features.Review.Commands.BulkResolveReviewItems;
 using MediaHandler.Application.Features.Review.Commands.ResolveReviewItem;
 using MediaHandler.Application.Features.Review.Queries.ListReviewItems;
@@ -40,10 +41,13 @@ public class AdminReviewController(ISender sender) : ControllerBase
         [FromQuery] Guid? scanRunId = null,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 25,
+        [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc",
+        [FromQuery] string? fileName = null,
         CancellationToken ct = default)
     {
         var result = await sender.Send(
-            new ListReviewItemsQuery(status, reason, scanRunId, page, pageSize), ct);
+            new ListReviewItemsQuery(status, reason, scanRunId, page, pageSize, sortField, sortOrder, fileName), ct);
 
         if (!result.IsSuccess)
             return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR",
@@ -149,5 +153,41 @@ public class AdminReviewController(ISender sender) : ControllerBase
         }
 
         return Ok(ApiResponse<BulkResolveResult>.Success(result.Value));
+    }
+
+    /// <summary>
+    ///     Batch-assign multiple review items to a single target media record.
+    ///     Resolves all specified review items to the target Media in one call.
+    ///     Returns per-item success/failure results.
+    ///     Returns 404 when <paramref name="request" />'s <c>targetMediaId</c> is not found.
+    /// </summary>
+    [HttpPost("batch-assign")]
+    [ProducesResponseType(typeof(ApiResponse<BatchAssignReviewItemsResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> BatchAssignReviewItems(
+        [FromBody] BatchAssignReviewItemsRequest request,
+        CancellationToken ct = default)
+    {
+        if (request.ReviewItemIds is null || request.ReviewItemIds.Length == 0)
+            return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR", "ReviewItemIds must not be empty.")));
+
+        var result = await sender.Send(
+            new BatchAssignReviewItemsCommand(request.ReviewItemIds, request.TargetMediaId), ct);
+
+        if (!result.IsSuccess)
+        {
+            var error = result.Errors.FirstOrDefault() ?? "Unknown error";
+
+            if (error.Contains("MEDIA_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
+                return NotFound(ApiResponse.Fail(new ApiError("MEDIA_NOT_FOUND",
+                    $"Media '{request.TargetMediaId}' was not found.")));
+
+            return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR", error)));
+        }
+
+        return Ok(ApiResponse<BatchAssignReviewItemsResponse>.Success(result.Value));
     }
 }

--- a/MediaHandler.API/Controllers/AdminScanController.cs
+++ b/MediaHandler.API/Controllers/AdminScanController.cs
@@ -160,9 +160,11 @@ public class AdminScanController(ISender sender) : ControllerBase
     public async Task<IActionResult> ListHistory(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 20,
+        [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc",
         CancellationToken ct = default)
     {
-        var result = await sender.Send(new ListScanHistoryQuery(page, pageSize), ct);
+        var result = await sender.Send(new ListScanHistoryQuery(page, pageSize, sortField, sortOrder), ct);
 
         if (!result.IsSuccess)
             return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR",
@@ -194,10 +196,13 @@ public class AdminScanController(ISender sender) : ControllerBase
         [FromQuery] Guid? libraryRootId = null,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
+        [FromQuery] string? sortField = null,
+        [FromQuery] string? sortOrder = "asc",
+        [FromQuery] string? fileName = null,
         CancellationToken ct = default)
     {
         var result = await sender.Send(
-            new ListScanDecisionsQuery(scanId, decisionType, mediaType, libraryRootId, page, pageSize), ct);
+            new ListScanDecisionsQuery(scanId, decisionType, mediaType, libraryRootId, page, pageSize, sortField, sortOrder, fileName), ct);
 
         if (!result.IsSuccess)
             return BadRequest(ApiResponse.Fail(new ApiError("VALIDATION_ERROR",

--- a/MediaHandler.Application/Features/Admin/Queries/GetUsers/GetUsersQueryHandler.cs
+++ b/MediaHandler.Application/Features/Admin/Queries/GetUsers/GetUsersQueryHandler.cs
@@ -8,7 +8,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MediaHandler.Application.Features.Admin.Queries.GetUsers;
 
-public record GetUsersQuery(int Page = 1, int PageSize = 20, string? Search = null)
+public record GetUsersQuery(int Page = 1, int PageSize = 20, string? Search = null,
+    string? SortField = null, string? SortOrder = "asc")
     : IRequest<Result<PagedResult<UserDto>>>;
 
 public class GetUsersQueryValidator : AbstractValidator<GetUsersQuery>
@@ -32,8 +33,21 @@ public class GetUsersQueryHandler(IApplicationDbContext context, IMapper mapper)
                                      (u.DisplayName != null && u.DisplayName.Contains(request.Search)));
 
         var total = await query.CountAsync(cancellationToken);
-        var entities = await query
-            .OrderBy(u => u.Email)
+
+        var ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("displayname", false) => query.OrderBy(u => u.DisplayName),
+            ("displayname", true) => query.OrderByDescending(u => u.DisplayName),
+            ("email", false) => query.OrderBy(u => u.Email),
+            ("email", true) => query.OrderByDescending(u => u.Email),
+            ("role", false) => query.OrderBy(u => u.Role),
+            ("role", true) => query.OrderByDescending(u => u.Role),
+            ("isactive", false) => query.OrderBy(u => u.IsActive),
+            ("isactive", true) => query.OrderByDescending(u => u.IsActive),
+            _ => query.OrderBy(u => u.Email),
+        };
+
+        var entities = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs
@@ -13,7 +13,9 @@ namespace MediaHandler.Application.Features.Dashboard.Queries.ListEnrichmentHist
 /// </summary>
 public record ListEnrichmentHistoryQuery(
     int Page,
-    int PageSize) : IRequest<PagedResult<EnrichmentRunDto>>;
+    int PageSize,
+    string? SortField = null,
+    string? SortOrder = "asc") : IRequest<PagedResult<EnrichmentRunDto>>;
 
 // =========================================================================
 // Validator
@@ -39,13 +41,20 @@ public sealed class ListEnrichmentHistoryQueryHandler(IApplicationDbContext db)
         ListEnrichmentHistoryQuery request,
         CancellationToken cancellationToken)
     {
-        var query = db.EnrichmentRuns
-            .AsNoTracking()
-            .OrderByDescending(r => r.StartedAt);
+        var query = db.EnrichmentRuns.AsNoTracking();
 
         var totalCount = await query.CountAsync(cancellationToken);
 
-        var items = await query
+        var ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("startedat", false) => query.OrderBy(r => r.StartedAt),
+            ("startedat", true) => query.OrderByDescending(r => r.StartedAt),
+            ("status", false) => query.OrderBy(r => r.Status),
+            ("status", true) => query.OrderByDescending(r => r.Status),
+            _ => query.OrderByDescending(r => r.StartedAt),
+        };
+
+        var items = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/MediaHandler.Application/Features/Dashboard/Queries/ListScanDecisions/ListScanDecisionsQuery.cs
+++ b/MediaHandler.Application/Features/Dashboard/Queries/ListScanDecisions/ListScanDecisionsQuery.cs
@@ -26,7 +26,10 @@ public record ListScanDecisionsQuery(
     MediaType? MediaType,
     Guid? LibraryRootId,
     int Page = 1,
-    int PageSize = 50) : IRequest<Result<PagedResult<ScanItemDecisionDto>>>;
+    int PageSize = 50,
+    string? SortField = null,
+    string? SortOrder = "asc",
+    string? FileName = null) : IRequest<Result<PagedResult<ScanItemDecisionDto>>>;
 
 // =========================================================================
 // Validator
@@ -77,10 +80,23 @@ public sealed class ListScanDecisionsQueryHandler(IApplicationDbContext db)
         if (request.LibraryRootId.HasValue)
             query = query.Where(d => d.LibraryRootId == request.LibraryRootId.Value);
 
+        if (!string.IsNullOrWhiteSpace(request.FileName))
+            query = query.Where(d => d.FilePath.Contains(request.FileName));
+
         var totalCount = await query.CountAsync(cancellationToken);
 
-        var items = await query
-            .OrderBy(d => d.FilePath)
+        var ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("filename", false) => query.OrderBy(d => d.FilePath),
+            ("filename", true) => query.OrderByDescending(d => d.FilePath),
+            ("status", false) => query.OrderBy(d => d.Kind),
+            ("status", true) => query.OrderByDescending(d => d.Kind),
+            ("createdat", false) => query.OrderBy(d => d.CreatedAt),
+            ("createdat", true) => query.OrderByDescending(d => d.CreatedAt),
+            _ => query.OrderBy(d => d.FilePath),
+        };
+
+        var items = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .Select(d => new

--- a/MediaHandler.Application/Features/LibraryRoots/Queries/ListLibraryRoots/ListLibraryRootsQuery.cs
+++ b/MediaHandler.Application/Features/LibraryRoots/Queries/ListLibraryRoots/ListLibraryRootsQuery.cs
@@ -12,7 +12,10 @@ public record ListLibraryRootsQuery(
     int Page = 1,
     int PageSize = 20,
     LibraryRootKind? Kind = null,
-    bool EnabledOnly = false) : IRequest<Result<PagedResult<LibraryRootDto>>>;
+    bool EnabledOnly = false,
+    string? SortField = null,
+    string? SortOrder = "asc",
+    string? Path = null) : IRequest<Result<PagedResult<LibraryRootDto>>>;
 
 public class ListLibraryRootsQueryValidator : AbstractValidator<ListLibraryRootsQuery>
 {
@@ -38,10 +41,21 @@ public sealed class ListLibraryRootsQueryHandler(IApplicationDbContext db)
         if (request.EnabledOnly)
             query = query.Where(r => r.IsEnabled);
 
+        if (!string.IsNullOrWhiteSpace(request.Path))
+            query = query.Where(r => r.Path.Contains(request.Path));
+
         var totalCount = await query.CountAsync(cancellationToken);
 
-        var items = await query
-            .OrderBy(r => r.Path)
+        var ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("path", false) => query.OrderBy(r => r.Path),
+            ("path", true) => query.OrderByDescending(r => r.Path),
+            ("createdat", false) => query.OrderBy(r => r.CreatedAt),
+            ("createdat", true) => query.OrderByDescending(r => r.CreatedAt),
+            _ => query.OrderBy(r => r.Path),
+        };
+
+        var items = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .Select(r => new LibraryRootDto(

--- a/MediaHandler.Application/Features/Media/DTOs/MediaDto.cs
+++ b/MediaHandler.Application/Features/Media/DTOs/MediaDto.cs
@@ -38,7 +38,8 @@ public record MediaListItemDto(
     int FileCount,
     bool? IsWatched,
     string? Status,
-    int? NumberOfSeasons);
+    int? NumberOfSeasons,
+    int? OwnedSeasonCount);
 
 public record MediaStatsDto(
     int TotalMedia,
@@ -47,4 +48,5 @@ public record MediaStatsDto(
     int WatchedByCurrentUser,
     int UnwatchedByCurrentUser,
     int TotalFiles,
-    int UnlinkedFiles);
+    int UnlinkedFiles,
+    int IncompleteTvShowCount);

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaList/GetMediaListQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaList/GetMediaListQueryHandler.cs
@@ -77,7 +77,8 @@ public class GetMediaListQueryHandler(IApplicationDbContext context, ICurrentUse
                         .FirstOrDefault()
                     : null,
                 m.Status,
-                m.NumberOfSeasons))
+                m.NumberOfSeasons,
+                m.Type == MediaType.TvShow ? (int?)m.TvSeasons.Count() : null))
             .ToListAsync(cancellationToken);
 
         return Result.Success(new PagedResult<MediaListItemDto>(items, total, request.Page, request.PageSize));

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaList/GetMediaListQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaList/GetMediaListQueryHandler.cs
@@ -51,8 +51,16 @@ public class GetMediaListQueryHandler(IApplicationDbContext context, ICurrentUse
             query = query.Where(m => m.Type == request.Type.Value);
 
         if (request.IsWatched.HasValue && userId.HasValue)
-            query = query.Where(m =>
-                m.UserMedias.Any(um => um.UserId == userId.Value && um.IsWatched == request.IsWatched.Value));
+        {
+            if (request.IsWatched.Value)
+                // Watched: must have a UserMedia entry with IsWatched = true
+                query = query.Where(m =>
+                    m.UserMedias.Any(um => um.UserId == userId.Value && um.IsWatched));
+            else
+                // Unwatched: no UserMedia entry at all, OR UserMedia with IsWatched = false
+                query = query.Where(m =>
+                    !m.UserMedias.Any(um => um.UserId == userId.Value && um.IsWatched));
+        }
 
         if (!string.IsNullOrWhiteSpace(request.Genre))
             query = query.Where(m => m.Genres.Any(g => g.Name == request.Genre));
@@ -78,7 +86,7 @@ public class GetMediaListQueryHandler(IApplicationDbContext context, ICurrentUse
                     : null,
                 m.Status,
                 m.NumberOfSeasons,
-                m.Type == MediaType.TvShow ? (int?)m.TvSeasons.Count() : null))
+                m.Type == MediaType.TvShow ? (int?)m.TvSeasons.Count(s => s.SeasonNumber > 0) : null))
             .ToListAsync(cancellationToken);
 
         return Result.Success(new PagedResult<MediaListItemDto>(items, total, request.Page, request.PageSize));

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
@@ -36,7 +36,9 @@ public class GetMediaStatsQueryHandler(IApplicationDbContext context, ICurrentUs
         var incompleteTvShows = await context.Medias
             .CountAsync(m => m.Type == MediaType.TvShow
                           && m.NumberOfSeasons.HasValue
-                          && m.TvSeasons.Count() < m.NumberOfSeasons.Value,
+                          && m.TvSeasons.Count(s =>
+                              s.SeasonNumber > 0 &&
+                              s.TvEpisodes.Any(e => e.EpisodeFileLinks.Any())) < m.NumberOfSeasons.Value,
                         cancellationToken);
 
         return Result.Success(new MediaStatsDto(

--- a/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
+++ b/MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs
@@ -33,6 +33,12 @@ public class GetMediaStatsQueryHandler(IApplicationDbContext context, ICurrentUs
             watchedByUser = await context.UserMedias
                 .CountAsync(um => um.UserId == userId.Value && um.IsWatched, cancellationToken);
 
+        var incompleteTvShows = await context.Medias
+            .CountAsync(m => m.Type == MediaType.TvShow
+                          && m.NumberOfSeasons.HasValue
+                          && m.TvSeasons.Count() < m.NumberOfSeasons.Value,
+                        cancellationToken);
+
         return Result.Success(new MediaStatsDto(
             totalMedia,
             films,
@@ -40,6 +46,7 @@ public class GetMediaStatsQueryHandler(IApplicationDbContext context, ICurrentUs
             watchedByUser,
             totalMedia - watchedByUser,
             totalFiles,
-            unlinkedFiles));
+            unlinkedFiles,
+            incompleteTvShows));
     }
 }

--- a/MediaHandler.Application/Features/Review/Commands/BatchAssignReviewItems/BatchAssignReviewItemsCommand.cs
+++ b/MediaHandler.Application/Features/Review/Commands/BatchAssignReviewItems/BatchAssignReviewItemsCommand.cs
@@ -1,0 +1,98 @@
+// BatchAssignReviewItems — command, validator, and handler for batch-assigning review items
+// to a single target Media entity using the internal Media.Id (Guid).
+
+using FluentValidation;
+using MediaHandler.Application.Common.Interfaces;
+using MediaHandler.Application.Common.Models;
+using MediaHandler.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MediaHandler.Application.Features.Review.Commands.BatchAssignReviewItems;
+
+/// <summary>Result for a single item in the batch.</summary>
+public record BatchAssignItemResult(
+    Guid ReviewItemId,
+    bool Success,
+    string? ErrorMessage);
+
+/// <summary>Response returned after a batch-assign operation.</summary>
+public record BatchAssignReviewItemsResponse(
+    IReadOnlyList<BatchAssignItemResult> Results);
+
+/// <summary>Command to assign multiple <c>ReviewItem</c> rows to a single target <c>Media</c>.</summary>
+public record BatchAssignReviewItemsCommand(
+    Guid[] ReviewItemIds,
+    Guid TargetMediaId) : IRequest<Result<BatchAssignReviewItemsResponse>>;
+
+// =========================================================================
+// Validator
+// =========================================================================
+
+public class BatchAssignReviewItemsCommandValidator : AbstractValidator<BatchAssignReviewItemsCommand>
+{
+    public BatchAssignReviewItemsCommandValidator()
+    {
+        RuleFor(x => x.ReviewItemIds)
+            .NotEmpty().WithMessage("ReviewItemIds must not be empty.");
+
+        RuleForEach(x => x.ReviewItemIds)
+            .NotEqual(Guid.Empty).WithMessage("Each ReviewItemId must be a valid non-empty GUID.");
+
+        RuleFor(x => x.TargetMediaId)
+            .NotEqual(Guid.Empty).WithMessage("TargetMediaId must be a valid non-empty GUID.");
+    }
+}
+
+// =========================================================================
+// Handler
+// =========================================================================
+
+/// <summary>
+///     Resolves all specified <c>ReviewItem</c> rows to the target <c>Media</c> entity.
+///     Returns per-item success/failure results; a single SaveChangesAsync is called after the loop.
+///     Returns <c>Result.Fail("MEDIA_NOT_FOUND")</c> when <see cref="BatchAssignReviewItemsCommand.TargetMediaId"/>
+///     does not correspond to an existing <c>Media</c> record.
+/// </summary>
+public sealed class BatchAssignReviewItemsCommandHandler(IApplicationDbContext db)
+    : IRequestHandler<BatchAssignReviewItemsCommand, Result<BatchAssignReviewItemsResponse>>
+{
+    public async Task<Result<BatchAssignReviewItemsResponse>> Handle(
+        BatchAssignReviewItemsCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Resolve target media once — fail the entire batch if not found
+        var media = await db.Medias
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == request.TargetMediaId, cancellationToken);
+
+        if (media is null)
+            return Result.Fail<BatchAssignReviewItemsResponse>("MEDIA_NOT_FOUND");
+
+        var results = new List<BatchAssignItemResult>(request.ReviewItemIds.Length);
+
+        foreach (var reviewItemId in request.ReviewItemIds)
+        {
+            var reviewItem = await db.ReviewItems
+                .FirstOrDefaultAsync(r => r.Id == reviewItemId, cancellationToken);
+
+            if (reviewItem is null)
+            {
+                results.Add(new BatchAssignItemResult(reviewItemId, false, "REVIEW_ITEM_NOT_FOUND"));
+                continue;
+            }
+
+            reviewItem.ResolvedTmdbId = media.TmdbId;
+            reviewItem.ResolvedKind = media.Type;
+            reviewItem.Status = ReviewStatus.Resolved;
+            reviewItem.ResolvedAt = DateTime.UtcNow;
+
+            results.Add(new BatchAssignItemResult(reviewItemId, true, null));
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(new BatchAssignReviewItemsResponse(results.AsReadOnly()));
+    }
+}
+

--- a/MediaHandler.Application/Features/Review/Queries/ListReviewItems/ListReviewItemsQuery.cs
+++ b/MediaHandler.Application/Features/Review/Queries/ListReviewItems/ListReviewItemsQuery.cs
@@ -23,7 +23,10 @@ public record ListReviewItemsQuery(
     ReviewReason? Reason = null,
     Guid? ScanRunId = null,
     int Page = 1,
-    int PageSize = 25) : IRequest<Result<PagedResult<ReviewItemDto>>>;
+    int PageSize = 25,
+    string? SortField = null,
+    string? SortOrder = "asc",
+    string? FileName = null) : IRequest<Result<PagedResult<ReviewItemDto>>>;
 
 // =========================================================================
 // Validator
@@ -67,10 +70,23 @@ public sealed class ListReviewItemsQueryHandler(IApplicationDbContext db)
         if (request.ScanRunId.HasValue)
             query = query.Where(r => r.FirstSeenScanRunId == request.ScanRunId.Value);
 
+        if (!string.IsNullOrWhiteSpace(request.FileName))
+            query = query.Where(r => r.FilePath.Contains(request.FileName));
+
         var totalCount = await query.CountAsync(cancellationToken);
 
-        var items = await query
-            .OrderByDescending(r => r.CreatedAt)
+        IOrderedQueryable<ReviewItem> ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("filename", false) => query.OrderBy(r => r.FilePath),
+            ("filename", true) => query.OrderByDescending(r => r.FilePath),
+            ("status", false) => query.OrderBy(r => r.Status),
+            ("status", true) => query.OrderByDescending(r => r.Status),
+            ("createdat", false) => query.OrderBy(r => r.CreatedAt),
+            ("createdat", true) => query.OrderByDescending(r => r.CreatedAt),
+            _ => query.OrderByDescending(r => r.CreatedAt),
+        };
+
+        var items = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/MediaHandler.Application/Features/Scan/Queries/ListScanHistory/ListScanHistoryQuery.cs
+++ b/MediaHandler.Application/Features/Scan/Queries/ListScanHistory/ListScanHistoryQuery.cs
@@ -15,7 +15,9 @@ namespace MediaHandler.Application.Features.Scan.Queries.ListScanHistory;
 /// </summary>
 public record ListScanHistoryQuery(
     int Page = 1,
-    int PageSize = 20) : IRequest<Result<PagedResult<ScanRunDto>>>;
+    int PageSize = 20,
+    string? SortField = null,
+    string? SortOrder = "asc") : IRequest<Result<PagedResult<ScanRunDto>>>;
 
 // =========================================================================
 // Validator
@@ -50,8 +52,18 @@ public sealed class ListScanHistoryQueryHandler(IApplicationDbContext db)
 
         var totalCount = await query.CountAsync(cancellationToken);
 
-        var items = await query
-            .OrderByDescending(r => r.StartedAt)
+        var ordered = (request.SortField?.ToLowerInvariant(), request.SortOrder?.ToLowerInvariant() == "desc") switch
+        {
+            ("startedat", false) => query.OrderBy(r => r.StartedAt),
+            ("startedat", true) => query.OrderByDescending(r => r.StartedAt),
+            ("status", false) => query.OrderBy(r => r.Status),
+            ("status", true) => query.OrderByDescending(r => r.Status),
+            ("mode", false) => query.OrderBy(r => r.Mode),
+            ("mode", true) => query.OrderByDescending(r => r.Mode),
+            _ => query.OrderByDescending(r => r.StartedAt),
+        };
+
+        var items = await ordered
             .Skip((request.Page - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
+++ b/MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs
@@ -274,6 +274,18 @@ public sealed class ScanPipeline(
                 scanRun, root, file, role, stack, counters, resolvedReviewItems, existingOpenReviewPaths,
                 existingMediaFiles, inFlightPaths, nfoEntriesByPath, language, ct);
 
+            if (processedInRoot % 10 == 0)
+            {
+                scanRun.TotalDiscovered = counters.TotalDiscovered;
+                scanRun.Added = counters.Added;
+                scanRun.Updated = counters.Updated;
+                scanRun.Unchanged = counters.Unchanged;
+                scanRun.Removed = counters.Removed;
+                scanRun.Excluded = counters.Excluded;
+                scanRun.NeedsReview = counters.NeedsReview;
+                await db.SaveChangesAsync(ct);
+            }
+
             if (processedInRoot % 50 == 0)
                 await EmitProgressAsync(scanRun.Id, "Classifying", processedInRoot, videoFiles.Count,
                     file.AbsolutePath, progress, ct);

--- a/specs/006-app-enhancements/plan.md
+++ b/specs/006-app-enhancements/plan.md
@@ -266,3 +266,252 @@ Both `MediaDto` and `MediaListItemDto` are constructed positionally in their res
 > No constitution violations. No entry required.
 
 All changes follow established patterns. No new packages, no new architecture layers, no deviation from CQRS/Result/FluentValidation conventions.
+
+---
+
+## Backend Work Required by Frontend Phases 13–20
+
+**Added**: 2025-07-24 | **Driven by**: Web `specs/006-app-enhancements/tasks.md` Phases 13–20 (T072–T122)
+
+### Summary
+
+The companion Angular frontend (MediaHandler.Web) phases 13–20 introduce four user stories that each require new or extended backend API behaviour. The work is grouped into four areas below and implemented as API Tasks T045–T055 (Phases 10–13 in `tasks.md`).
+
+### Constitution Check — New Work
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Clean Architecture | ✅ PASS | All new queries/commands in Application layer; controller changes in API layer; `ScanPipeline` change in Infrastructure. |
+| I. CQRS via MediatR | ✅ PASS | `BatchAssignReviewItemsCommand` is a new Command+Handler pair. Sort/filter params added to existing queries. |
+| I. Result pattern | ✅ PASS | `BatchAssignReviewItemsCommand` returns `Result<BatchAssignReviewItemsResponse>`. Existing queries retain their own return types. |
+| I. FluentValidation pipeline | ✅ PASS | `BatchAssignReviewItemsCommand` validator: array non-empty, each `ReviewItemId` non-empty. |
+| I. Code style | ✅ PASS | File-scoped namespaces, `record` types, `#nullable enable`. |
+| IV. Performance | ✅ PASS | `AsNoTracking()` retained on all read queries. Batch assign uses a single `Media` lookup + loop. Incremental flush limited to every 10 files to avoid excessive DB round-trips. |
+| III. Versioned routes | ✅ PASS | New endpoint `POST /api/v1/admin/review-items/batch-assign` follows existing `/api/v1/admin/…` convention. |
+| III. Role-based access | ✅ PASS | New endpoint uses existing AdminOnly policy, consistent with all other `AdminReviewController` actions. |
+
+**Gate result**: ✅ ALL PASS — no violations. Proceeding to implementation.
+
+---
+
+### A. Sort & Filter on Six Admin List Endpoints
+
+**Web tasks**: T072–T077 | **API tasks**: T045–T050 | **Unblocks**: Web Phase 14 (US-9 table sort/filter)
+
+All six admin list endpoints already accept `page`/`pageSize` as `[FromQuery]` parameters. Each query record and its handler will be extended with two new optional parameters (`string? SortField`, `string? SortOrder`) and, where applicable, a column-specific text-filter parameter. Ordering is appended to the `IQueryable` before the `Skip`/`Take` via a `switch` expression; the fallback order (the current default) is preserved when `SortField` is null.
+
+| Endpoint | Query | New params | Filter field | Sort columns |
+|----------|-------|-----------|--------------|--------------|
+| `GET /api/v1/admin/users` | `GetUsersQuery` | `SortField?`, `SortOrder?` | — | `DisplayName`, `Email`, `Role`, `IsActive` |
+| `GET /api/v1/admin/review-items` | `ListReviewItemsQuery` | `SortField?`, `SortOrder?`, `FileName?` | `Contains(FilePath)` | `FileName`, `Status`, `CreatedAt` |
+| `GET /api/v1/admin/scan/history` | `ListScanHistoryQuery` | `SortField?`, `SortOrder?` | — | `StartedAt`, `Status`, `Mode` |
+| `GET /api/v1/admin/scan/decisions` | `ListScanDecisionsQuery` | `SortField?`, `SortOrder?`, `FileName?` | `Contains(FilePath)` | `FileName`, `Status`, `CreatedAt` |
+| `GET /api/v1/admin/enrichment/history` | `ListEnrichmentHistoryQuery` | `SortField?`, `SortOrder?` | — | `StartedAt`, `Status` |
+| `GET /api/v1/admin/library-roots` | `ListLibraryRootsQuery` | `SortField?`, `SortOrder?`, `Path?` | `Contains(Path)` | `Path`, `CreatedAt` |
+
+**Implementation pattern** (same for all six):
+
+```csharp
+// In query record — append optional params after existing pagination params:
+public record GetUsersQuery(
+    int Page = 1,
+    int PageSize = 20,
+    string? Search = null,
+    string? SortField = null,
+    string? SortOrder = "asc") : IRequest<Result<PagedResult<UserDto>>>;
+
+// In handler — replace the current .OrderBy(…) with a switch:
+IOrderedQueryable<User> ordered = (SortField?.ToLowerInvariant(), SortOrder?.ToLowerInvariant() == "desc") switch
+{
+    ("displayname", false) => query.OrderBy(u => u.DisplayName),
+    ("displayname", true)  => query.OrderByDescending(u => u.DisplayName),
+    ("email",       false) => query.OrderBy(u => u.Email),
+    ("email",       true)  => query.OrderByDescending(u => u.Email),
+    ("role",        false) => query.OrderBy(u => u.Role),
+    ("role",        true)  => query.OrderByDescending(u => u.Role),
+    ("isactive",    false) => query.OrderBy(u => u.IsActive),
+    ("isactive",    true)  => query.OrderByDescending(u => u.IsActive),
+    _                      => query.OrderBy(u => u.Email),   // existing default
+};
+```
+
+For text-filter params (`FileName`, `Path`), the filter is applied before the count and ordering:
+
+```csharp
+if (!string.IsNullOrWhiteSpace(request.FileName))
+    query = query.Where(r => r.FilePath.Contains(request.FileName));
+```
+
+Each controller action receives the new params from `[FromQuery]` and forwards them to the query constructor unchanged.
+
+---
+
+### B. Incremental Scan Counter Flush
+
+**Web tasks**: T078 (duplicate intent in T096) | **API task**: T051 | **Unblocks**: Web Phase 16 (US-11 real-time counters)
+
+**Problem**: `ScanPipeline.ExecuteAsync` accumulates counters in the in-memory `ScanCounters` struct and writes them to `scanRun` only at the very end (lines 82–89 of `ExecuteAsync`). The `GET /api/v1/admin/scan/active` endpoint reads these fields from the DB, so they remain 0 throughout the entire scan.
+
+**Fix location**: `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs` — inside the `foreach (var file in videoFiles)` loop in `ProcessRootAsync` (around line 277, where `processedInRoot % 50 == 0` already triggers a progress emit).
+
+**Implementation**:
+
+```csharp
+// After ClassifyAndPersistFileAsync call, inside the foreach (var file in videoFiles) loop:
+if (processedInRoot % 10 == 0)
+{
+    scanRun.TotalDiscovered = counters.TotalDiscovered;
+    scanRun.Added           = counters.Added;
+    scanRun.Updated         = counters.Updated;
+    scanRun.Unchanged       = counters.Unchanged;
+    scanRun.Removed         = counters.Removed;
+    scanRun.Excluded        = counters.Excluded;
+    scanRun.NeedsReview     = counters.NeedsReview;
+    await db.SaveChangesAsync(ct);
+}
+```
+
+The `counters.TotalDiscovered` increment at line 175 covers ALL enumerated entries (including excluded dirs). The `processedInRoot` counter in the video-file loop tracks only video files. Flushing every 10 video files ensures the active-scan endpoint reflects useful progress while keeping additional DB round-trips to a minimum (1 extra save per 10 files vs the existing 1 save per root).
+
+> **Note**: The Web tasks.md T078 and T096 both describe the same fix and attribute it to `ScanRunCoordinator.cs`. That file orchestrates scans but does not own the `ScanCounters` struct — the counters live in `ScanPipeline.cs` and must be flushed there.
+
+---
+
+### C. Batch Assign Review Items
+
+**Web tasks**: T079–T080 | **API tasks**: T052–T053 | **Unblocks**: Web Phase 17 (US-12 multi-select batch assign)
+
+A new command `BatchAssignReviewItemsCommand` assigns multiple `ReviewItem` rows to a single target `Media` entity in one operation. Unlike `ResolveReviewItemCommand` (which accepts a TmdbId + Kind and performs a TMDB-lookup to find the Media), this command takes the internal `Media.Id` (Guid) directly — the frontend has already resolved the target media via the existing `GET /api/v1/media?title=…` search.
+
+**New files**:
+
+```text
+MediaHandler.Application/Features/Review/Commands/BatchAssignReviewItems/
+└── BatchAssignReviewItemsCommand.cs   ← command record + validator + handler
+MediaHandler.API/Contracts/Admin/
+└── ReviewRequests.cs                  ← MODIFIED: add BatchAssignReviewItemsRequest,
+                                                   BatchAssignItemResult,
+                                                   BatchAssignReviewItemsResponse
+MediaHandler.API/Controllers/
+└── AdminReviewController.cs           ← MODIFIED: add POST batch-assign action
+```
+
+**Command shape**:
+
+```csharp
+public record BatchAssignReviewItemsCommand(
+    Guid[] ReviewItemIds,
+    Guid TargetMediaId) : IRequest<Result<BatchAssignReviewItemsResponse>>;
+
+public record BatchAssignItemResult(
+    Guid ReviewItemId,
+    bool Success,
+    string? ErrorMessage);
+
+public record BatchAssignReviewItemsResponse(
+    IReadOnlyList<BatchAssignItemResult> Results);
+```
+
+**Handler logic** (per item):
+1. Resolve `ReviewItem` by `id` — record failure if not found.
+2. Resolve `Media` by `TargetMediaId` (once, outside the loop) — fail the entire batch if not found.
+3. Set `reviewItem.ResolvedTmdbId = media.TmdbId`, `reviewItem.ResolvedKind = media.Type`, `reviewItem.AssignedMediaId = media.Id` (if the domain entity has that FK), `reviewItem.Status = ReviewStatus.Resolved`, `reviewItem.ResolvedAt = DateTime.UtcNow`.
+4. Collect per-item `BatchAssignItemResult`; continue on per-item exceptions.
+5. `SaveChangesAsync` once after the loop.
+6. Return `Result.Success(new BatchAssignReviewItemsResponse(results))`.
+
+**Validator**: `ReviewItemIds` must be non-empty; `TargetMediaId` must be non-empty.
+
+**Endpoint**:
+
+```
+POST /api/v1/admin/review-items/batch-assign
+Authorization: AdminOnly
+Body: { "reviewItemIds": ["…"], "targetMediaId": "…" }
+200 OK: ApiResponse<BatchAssignReviewItemsResponse>
+400 Bad Request: empty array / missing targetMediaId
+404 Not Found: targetMediaId does not correspond to a Media record
+```
+
+---
+
+### D. Collection Completeness Data
+
+**Web tasks**: T081–T082 | **API tasks**: T054–T055 | **Unblocks**: Web Phase 19 (US-14 completeness badges)
+
+Two additive DTO changes surface TV show completeness information without any schema migration.
+
+#### D.1 — `MediaStatsDto.IncompleteTvShowCount`
+
+Add `int IncompleteTvShowCount` as the last field in `MediaStatsDto` (same file: `MediaDto.cs`). Compute in `GetMediaStatsQueryHandler`:
+
+```csharp
+var incompleteTvShows = await context.Medias
+    .CountAsync(m => m.Type == MediaType.TvShow
+                  && m.NumberOfSeasons.HasValue
+                  && m.TvSeasons.Count() < m.NumberOfSeasons.Value,
+                cancellationToken);
+```
+
+Pass `incompleteTvShows` as the last positional argument in the `new MediaStatsDto(…)` constructor call.
+
+#### D.2 — `MediaListItemDto.OwnedSeasonCount`
+
+Add `int? OwnedSeasonCount` as the last field in `MediaListItemDto`. Project it in `GetMediaListQueryHandler`'s `.Select(m => new MediaListItemDto(…))`:
+
+```csharp
+m.Type == MediaType.TvShow ? (int?)m.TvSeasons.Count() : null
+```
+
+Films receive `null`; TV shows receive the count of persisted `TvSeason` rows. EF Core translates `m.TvSeasons.Count()` to a correlated subquery — no `Include` needed.
+
+---
+
+### Source Structure — New & Modified Files (Phases 10–13)
+
+```text
+MediaHandler.Application/
+├── Features/
+│   ├── Admin/Queries/GetUsers/
+│   │   └── GetUsersQueryHandler.cs             ← MODIFIED: add SortField?, SortOrder?
+│   ├── Review/
+│   │   ├── Queries/ListReviewItems/
+│   │   │   └── ListReviewItemsQuery.cs          ← MODIFIED: add SortField?, SortOrder?, FileName?
+│   │   └── Commands/BatchAssignReviewItems/
+│   │       └── BatchAssignReviewItemsCommand.cs ← NEW: command + validator + handler
+│   ├── Scan/Queries/ListScanHistory/
+│   │   └── ListScanHistoryQuery.cs              ← MODIFIED: add SortField?, SortOrder?
+│   ├── Dashboard/Queries/
+│   │   ├── ListScanDecisions/
+│   │   │   └── ListScanDecisionsQuery.cs        ← MODIFIED: add SortField?, SortOrder?, FileName?
+│   │   └── ListEnrichmentHistory/
+│   │       └── ListEnrichmentHistoryQuery.cs    ← MODIFIED: add SortField?, SortOrder?
+│   ├── LibraryRoots/Queries/ListLibraryRoots/
+│   │   └── ListLibraryRootsQuery.cs             ← MODIFIED: add SortField?, SortOrder?, Path?
+│   └── Media/
+│       ├── DTOs/
+│       │   └── MediaDto.cs                      ← MODIFIED: IncompleteTvShowCount on MediaStatsDto;
+│       │                                                     OwnedSeasonCount on MediaListItemDto
+│       ├── Queries/GetMediaStats/
+│       │   └── GetMediaStatsQueryHandler.cs     ← MODIFIED: compute IncompleteTvShowCount
+│       └── Queries/GetMediaList/
+│           └── GetMediaListQueryHandler.cs      ← MODIFIED: project OwnedSeasonCount
+
+MediaHandler.Infrastructure/
+└── Nas/Scanner/
+    └── ScanPipeline.cs                          ← MODIFIED: incremental counter flush every 10 files
+
+MediaHandler.API/
+├── Contracts/Admin/
+│   └── ReviewRequests.cs                        ← MODIFIED: add BatchAssignReviewItemsRequest,
+│                                                             BatchAssignItemResult,
+│                                                             BatchAssignReviewItemsResponse
+└── Controllers/
+    ├── AdminController.cs                       ← MODIFIED: forward SortField?, SortOrder? to GetUsersQuery
+    ├── AdminReviewController.cs                 ← MODIFIED: forward sort/filter params; add batch-assign action
+    ├── AdminScanController.cs                   ← MODIFIED: forward SortField?, SortOrder? to ListScanHistoryQuery
+    ├── AdminScanDecisionsController.cs          ← MODIFIED: forward sort/fileName params to ListScanDecisionsQuery
+    ├── AdminEnrichmentController.cs             ← MODIFIED: forward SortField?, SortOrder? to ListEnrichmentHistoryQuery
+    └── AdminLibraryRootsController.cs           ← MODIFIED: forward sort/path params to ListLibraryRootsQuery
+```
+

--- a/specs/006-app-enhancements/tasks.md
+++ b/specs/006-app-enhancements/tasks.md
@@ -190,6 +190,77 @@
 
 ---
 
+## Phase 10: Sort & Filter on Admin List Endpoints (Unblocks Web US-9)
+
+**Purpose**: Extend all six admin list query handlers with optional `sortField`/`sortOrder` parameters and column-specific text filters so the frontend PrimeNG `p-table` components can delegate sort and filter to the server. Each query already has `page`/`pageSize`; this phase adds the complementary sort/filter surface.
+
+**Goal**: `GET /api/v1/admin/users?sortField=displayName&sortOrder=desc` returns users sorted by `DisplayName` descending. `GET /api/v1/admin/review-items?fileName=Inception` returns only items whose `FilePath` contains `"Inception"`. All six endpoints behave identically to today when the new params are omitted.
+
+**Independent Test**: Call each endpoint with `?sortField=<column>&sortOrder=desc` and verify ordering; call endpoints with a text filter value and verify filtering. Omit params and verify existing behaviour is unchanged.
+
+### Implementation
+
+- [X] T045 [P] Add `string? SortField = null` and `string? SortOrder = "asc"` as the last two positional parameters to `GetUsersQuery` record in `MediaHandler.Application/Features/Admin/Queries/GetUsers/GetUsersQueryHandler.cs`; replace the hardcoded `query.OrderBy(u => u.Email)` with a `switch (SortField?.ToLowerInvariant(), SortOrder?.ToLowerInvariant() == "desc")` that maps `"displayname"`, `"email"`, `"role"`, `"isactive"` to ascending/descending `OrderBy`/`OrderByDescending` calls, with `OrderBy(u => u.Email)` as the default case; update `AdminController.GetUsers()` in `MediaHandler.API/Controllers/AdminController.cs` to accept `[FromQuery] string? sortField = null` and `[FromQuery] string? sortOrder = "asc"` and pass them to the query constructor — verify `dotnet build`
+- [X] T046 [P] Add `string? SortField = null`, `string? SortOrder = "asc"`, and `string? FileName = null` as the last three positional parameters to `ListReviewItemsQuery` record in `MediaHandler.Application/Features/Review/Queries/ListReviewItems/ListReviewItemsQuery.cs`; apply `query = query.Where(r => r.FilePath.Contains(request.FileName))` when `FileName` is non-null/non-whitespace; replace the hardcoded `OrderByDescending(r => r.CreatedAt)` with a `switch` covering `"filename"` (maps to `r.FilePath`), `"status"`, `"createdat"`, with `OrderByDescending(r => r.CreatedAt)` as default; update `AdminReviewController.ListReviewItems()` in `MediaHandler.API/Controllers/AdminReviewController.cs` to accept and forward `[FromQuery] string? sortField`, `string? sortOrder`, `string? fileName` — verify `dotnet build`
+- [X] T047 [P] Add `string? SortField = null` and `string? SortOrder = "asc"` as the last two positional parameters to `ListScanHistoryQuery` record in `MediaHandler.Application/Features/Scan/Queries/ListScanHistory/ListScanHistoryQuery.cs`; replace the hardcoded `OrderByDescending(r => r.StartedAt)` with a `switch` covering `"startedat"`, `"status"`, `"mode"`, with `OrderByDescending(r => r.StartedAt)` as default; update `AdminScanController.ListHistory()` in `MediaHandler.API/Controllers/AdminScanController.cs` to accept and forward the new `[FromQuery]` params — verify `dotnet build`
+- [X] T048 [P] Add `string? SortField = null`, `string? SortOrder = "asc"`, and `string? FileName = null` as the last three positional parameters to `ListScanDecisionsQuery` record in `MediaHandler.Application/Features/Dashboard/Queries/ListScanDecisions/ListScanDecisionsQuery.cs`; apply `Contains(request.FileName)` filter on `d.FilePath` when `FileName` is non-null; replace the hardcoded `OrderBy(d => d.FilePath)` with a `switch` covering `"filename"` (maps to `d.FilePath`), `"status"` (maps to `d.Kind`), `"createdat"` (maps to `d.CreatedAt`), with `OrderBy(d => d.FilePath)` as default; update the scan decisions controller action in `MediaHandler.API/Controllers/AdminScanDecisionsController.cs` to accept and forward the new params — verify `dotnet build`
+- [X] T049 [P] Add `string? SortField = null` and `string? SortOrder = "asc"` as the last two positional parameters to `ListEnrichmentHistoryQuery` record in `MediaHandler.Application/Features/Dashboard/Queries/ListEnrichmentHistory/ListEnrichmentHistoryQuery.cs`; replace the hardcoded `OrderByDescending(r => r.StartedAt)` with a `switch` covering `"startedat"`, `"status"`, with `OrderByDescending(r => r.StartedAt)` as default; note that this query returns `PagedResult<EnrichmentRunDto>` directly (not `Result<…>`), so no change to the return-type wrapper is needed; update `AdminEnrichmentController.ListHistory()` in `MediaHandler.API/Controllers/AdminEnrichmentController.cs` to accept and forward the new params — verify `dotnet build`
+- [X] T050 [P] Add `string? SortField = null`, `string? SortOrder = "asc"`, and `string? Path = null` as the last three positional parameters to `ListLibraryRootsQuery` record in `MediaHandler.Application/Features/LibraryRoots/Queries/ListLibraryRoots/ListLibraryRootsQuery.cs`; apply `query = query.Where(r => r.Path.Contains(request.Path))` when `Path` is non-null; replace the hardcoded `OrderBy(r => r.Path)` with a `switch` covering `"path"`, `"createdat"`, with `OrderBy(r => r.Path)` as default; update `AdminLibraryRootsController.List()` in `MediaHandler.API/Controllers/AdminLibraryRootsController.cs` to accept and forward the new params — verify `dotnet build`
+
+**Checkpoint**: All six admin list endpoints accept `sortField`/`sortOrder` and their respective text filters. Omitting the new params returns data in the same default order as before. `dotnet build` succeeds with zero warnings.
+
+---
+
+## Phase 11: Incremental Scan Counter Flush (Unblocks Web US-11)
+
+**Purpose**: The `GET /api/v1/admin/scan/active` endpoint reads scan counters (`TotalDiscovered`, `Added`, `Updated`, `NeedsReview`) from the `ScanRun` DB row, which currently stays at zero until the entire scan finishes. Flushing the in-memory `ScanCounters` struct to the DB every 10 video files makes the counters visible mid-scan within the first two 4-second polling cycles.
+
+**Goal**: Start a scan on a library with >10 files; within ~8 seconds (two polling intervals), `GET /api/v1/admin/scan/active` returns at least one counter > 0.
+
+**Independent Test**: Run a scan on a library with 20+ files; confirm `GET /api/v1/admin/scan/active` returns non-zero `counts` before the scan completes.
+
+### Implementation
+
+- [X] T051 Inside the `foreach (var file in videoFiles)` loop in `ProcessRootAsync` in `MediaHandler.Infrastructure/Nas/Scanner/ScanPipeline.cs` (immediately after the `ClassifyAndPersistFileAsync` call, at the same position as the existing `processedInRoot % 50 == 0` progress-emit block), add an incremental counter flush every 10 files: `if (processedInRoot % 10 == 0) { scanRun.TotalDiscovered = counters.TotalDiscovered; scanRun.Added = counters.Added; scanRun.Updated = counters.Updated; scanRun.Unchanged = counters.Unchanged; scanRun.Removed = counters.Removed; scanRun.Excluded = counters.Excluded; scanRun.NeedsReview = counters.NeedsReview; await db.SaveChangesAsync(ct); }` — the existing final flush at lines 82–89 of `ExecuteAsync` is retained unchanged as the authoritative end-of-scan snapshot — verify `dotnet build` and run a test scan confirming non-zero counters mid-run
+
+**Checkpoint**: Scanner counters are visible in `GET /api/v1/admin/scan/active` after the first 10 video files have been processed. The final counter flush at scan completion is unaffected.
+
+---
+
+## Phase 12: Batch Assign Review Items (Unblocks Web US-12)
+
+**Purpose**: Introduce a `BatchAssignReviewItemsCommand` that resolves multiple `ReviewItem` rows to the same target `Media` in a single request, and expose it via `POST /api/v1/admin/review-items/batch-assign`. Unlike the existing `ResolveReviewItemCommand` (which accepts a TmdbId + Kind and performs a DB lookup), this command uses the internal `Media.Id` (Guid) directly — the frontend has already resolved the target via `GET /api/v1/media?title=…` search.
+
+**Goal**: `POST /api/v1/admin/review-items/batch-assign` with `{ "reviewItemIds": ["…","…"], "targetMediaId": "…" }` resolves all specified review items to the target media in one call and returns per-item success/failure results.
+
+**Independent Test**: POST with 3 valid ReviewItemIds + a valid targetMediaId — verify all 3 items are resolved (Status = Resolved) and the response contains 3 `success: true` entries. POST with one invalid ReviewItemId mixed in — verify the valid ones succeed and the invalid one produces `success: false` with a descriptive error message. POST with an unknown `targetMediaId` — verify 404.
+
+### Implementation
+
+- [X] T052 Create `BatchAssignReviewItemsCommand` record (`Guid[] ReviewItemIds`, `Guid TargetMediaId`) implementing `IRequest<Result<BatchAssignReviewItemsResponse>>`; add `BatchAssignReviewItemsCommandValidator` (FluentValidation: `ReviewItemIds` must not be empty, each element must not be `Guid.Empty`, `TargetMediaId` must not be `Guid.Empty`); implement handler: (1) resolve `Media` by `TargetMediaId` via `db.Medias.FindAsync` — return `Result.Fail("MEDIA_NOT_FOUND")` if null, (2) for each `ReviewItemId` in a loop: find `ReviewItem` by id — if not found record `BatchAssignItemResult(id, false, "REVIEW_ITEM_NOT_FOUND")`; otherwise set `reviewItem.ResolvedTmdbId = media.TmdbId`, `reviewItem.ResolvedKind = media.Type`, `reviewItem.Status = ReviewStatus.Resolved`, `reviewItem.ResolvedAt = DateTime.UtcNow`, record `BatchAssignItemResult(id, true, null)`; (3) `await db.SaveChangesAsync(cancellationToken)` once after the loop; (4) return `Result.Success(new BatchAssignReviewItemsResponse(results))` — all in `MediaHandler.Application/Features/Review/Commands/BatchAssignReviewItems/BatchAssignReviewItemsCommand.cs`; also add `BatchAssignReviewItemsRequest(Guid[] ReviewItemIds, Guid TargetMediaId)`, `BatchAssignItemResult(Guid ReviewItemId, bool Success, string? ErrorMessage)`, and `BatchAssignReviewItemsResponse(IReadOnlyList<BatchAssignItemResult> Results)` records to `MediaHandler.API/Contracts/Admin/ReviewRequests.cs` — verify `dotnet build`
+- [X] T053 Add `POST /api/v1/admin/review-items/batch-assign` action to `AdminReviewController` in `MediaHandler.API/Controllers/AdminReviewController.cs`: accept `[FromBody] BatchAssignReviewItemsRequest request`; validate that `request.ReviewItemIds` is non-empty (return `400 Bad Request ApiResponse` if empty); dispatch `new BatchAssignReviewItemsCommand(request.ReviewItemIds, request.TargetMediaId)` via `_mediator`; map `Result.IsFailure` to `404 Not Found` when the failure code is `"MEDIA_NOT_FOUND"`; return `200 OK ApiResponse<BatchAssignReviewItemsResponse>` on success; add `[ProducesResponseType(typeof(ApiResponse<BatchAssignReviewItemsResponse>), 200)]`, `[ProducesResponseType(400)]`, `[ProducesResponseType(403)]`, `[ProducesResponseType(404)]` attributes — depends on T052; verify `dotnet build` and a test POST confirming per-item results in the response
+
+**Checkpoint**: `POST /api/v1/admin/review-items/batch-assign` is live. Multiple review items can be resolved to a single target media in one call. Per-item failures are captured and returned without failing the entire batch.
+
+---
+
+## Phase 13: Collection Completeness Data (Unblocks Web US-14)
+
+**Purpose**: Surface TV show completeness information in two existing endpoints without any schema migration. `GET /api/v1/media/stats` gains an `incompleteTvShowCount` stat; `GET /api/v1/media` list items gain an `ownedSeasonCount` field for TV shows (null for films). Both changes are purely additive DTO extensions with computed EF Core projections.
+
+**Goal**: `GET /api/v1/media/stats` returns `"incompleteTvShowCount": 3` when 3 TV shows have fewer `TvSeason` records than `NumberOfSeasons`. `GET /api/v1/media` returns `"ownedSeasonCount": 2` for a TV show that has 2 persisted `TvSeason` rows, and `"ownedSeasonCount": null` for films.
+
+**Independent Test**: For a TV show with `numberOfSeasons = 4` and 2 persisted `TvSeason` rows: confirm `GET /api/v1/media` returns `ownedSeasonCount: 2`; confirm `GET /api/v1/media/stats` includes that show in `incompleteTvShowCount`. For a film: confirm `ownedSeasonCount: null`. For the stats endpoint: confirm count decreases by 1 after adding a missing season record.
+
+### Implementation
+
+- [X] T054 Add `int IncompleteTvShowCount` as the last positional parameter to `MediaStatsDto` record in `MediaHandler.Application/Features/Media/DTOs/MediaDto.cs`; update `GetMediaStatsQueryHandler.Handle` in `MediaHandler.Application/Features/Media/Queries/GetMediaStats/GetMediaStatsQueryHandler.cs` to compute `var incompleteTvShows = await context.Medias.CountAsync(m => m.Type == MediaType.TvShow && m.NumberOfSeasons.HasValue && m.TvSeasons.Count() < m.NumberOfSeasons.Value, cancellationToken)` and pass it as the last argument in `new MediaStatsDto(totalMedia, films, tvShows, watchedByUser, totalMedia - watchedByUser, totalFiles, unlinkedFiles, incompleteTvShows)` — verify `dotnet build` and confirm `GET /api/v1/media/stats` response includes `incompleteTvShowCount`
+- [X] T055 Add `int? OwnedSeasonCount` as the last positional parameter to `MediaListItemDto` record in `MediaHandler.Application/Features/Media/DTOs/MediaDto.cs`; update the `.Select(m => new MediaListItemDto(…))` projection in `GetMediaListQueryHandler.Handle` in `MediaHandler.Application/Features/Media/Queries/GetMediaList/GetMediaListQueryHandler.cs` to append `m.Type == MediaType.TvShow ? (int?)m.TvSeasons.Count() : null` as the last argument — EF Core translates this to a correlated subquery; no `Include` or additional DB calls needed — verify `dotnet build` and confirm `GET /api/v1/media` list items include `ownedSeasonCount` for TV shows and `null` for films
+
+**Checkpoint**: `GET /api/v1/media/stats` returns `incompleteTvShowCount` and `GET /api/v1/media` returns `ownedSeasonCount`. Films receive `null`. No migration required — `TvSeasons` and `NumberOfSeasons` already exist on the `Media` entity.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies
@@ -204,6 +275,10 @@ Phase 1 (Domain + DTOs)
   └── Phase 7 (Tests): depends on Phases 2–6
 Phase 8 (Polish): depends on all prior phases
 Phase 9 (Enrichment Language): T038+T039 parallel → T040 → T041; T039 → T042 → T043; T044 validates all
+Phase 10 (Sort/Filter): T045–T050 are all fully independent and can run in parallel (different files)
+Phase 11 (Counter Flush): T051 is independent; can run in parallel with Phase 10
+Phase 12 (Batch Assign): T052 → T053 (endpoint depends on command); T052 independent of Phases 10–11
+Phase 13 (Completeness Data): T054 and T055 are independent (same file, different records); both independent of Phases 10–12
 ```
 
 ### Parallel Opportunities
@@ -220,6 +295,10 @@ Phase 9 (Enrichment Language): T038+T039 parallel → T040 → T041; T039 → T0
 
 **Within Phase 9** — T038 (`ScanRequests.cs`) and T039 (`IEnrichmentCoordinator.cs`) are fully independent and can run in parallel. T040 (`StartEnrichmentCommand.cs`) depends on T039; T041 (`AdminEnrichmentController.cs`) depends on T038+T040; T042 (`EnrichmentCoordinator.StartAsync`) depends on T039; T043 (private method language wiring) depends on T042; T044 (build + smoke-test) depends on all prior Phase 9 tasks.
 
+**Within Phase 10** — T045–T050 each target a different query file and a different controller file; all six can run simultaneously.
+
+**Phase 10 vs Phase 11 vs Phase 12 vs Phase 13** — All four new phases are independent of each other and can run in parallel. T053 depends on T052; T055 and T054 can run in parallel (same file, no dependency between the two changes).
+
 ### Suggested MVP Scope
 
 **User Story 1 + User Story 2 only** (Phases 1–3):
@@ -230,4 +309,6 @@ Phase 9 (Enrichment Language): T038+T039 parallel → T040 → T041; T039 → T0
 - Ship scan language + media DTO fields first; profile-picture feature (Phases 4–6) can follow
 
 **Phase 9 (Enrichment Language)** is a self-contained follow-on to Phase 2 that can be shipped independently once Phase 8 is complete — it touches only three files across two layers (Application + Infrastructure) and introduces no schema changes or new endpoints.
+
+**Phases 10–13 (Frontend-driven enhancements)** are all additive and independent — any can be shipped in isolation once Phase 8 is complete. No new migrations. Phase 12 (Batch Assign) is the only phase that adds a new endpoint; Phases 10, 11, and 13 extend existing endpoints only.
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features across the API, focusing on improved sorting and filtering capabilities for list endpoints, the addition of a batch-assign operation for review items, and new fields in media-related DTOs. The main themes are API usability improvements, backend query flexibility, and enriched statistics for media entities.

**API and Query Enhancements**

* Added support for sorting and additional filtering to various list endpoints:
  - User listing (`GetUsersQuery` and controller): now supports `sortField` and `sortOrder` parameters, allowing sorting by display name, email, role, or active status. [[1]](diffhunk://#diff-f33f1c66ba2056f7d74bb9119de4b29018da88d369a4927fa3b333c06d946ad6L25-R28) [[2]](diffhunk://#diff-7de26fccfba047b42f42cebedd8d1ceb430ad82f7555800eb9bd8f43c757e596L11-R12) [[3]](diffhunk://#diff-7de26fccfba047b42f42cebedd8d1ceb430ad82f7555800eb9bd8f43c757e596L35-R50)
  - Enrichment history, scan history, scan decisions, review items, and library roots list endpoints: now accept sorting parameters and, where appropriate, extra filters such as `fileName` or `path`. Corresponding query handlers implement the new sorting logic. [[1]](diffhunk://#diff-0d2b9e0b2fb40e6f19467432a5fe0c04853375be4ce18dc0b84e77cc584b0807R126-R130) [[2]](diffhunk://#diff-dd49e70ea05ed70555fb394eeb1ef61d52837329175c673377b0c49c7d876d02R163-R167) [[3]](diffhunk://#diff-dd49e70ea05ed70555fb394eeb1ef61d52837329175c673377b0c49c7d876d02R199-R205) [[4]](diffhunk://#diff-830b1f71036e8e251d988b0468511409040f65792c6c6c111bbf8faf2c39f2acR44-R50) [[5]](diffhunk://#diff-050713f5c3ad413cce6abd28e43166e75de4da7d5c56abda153e66ed76cb0b36L15-R18) [[6]](diffhunk://#diff-050713f5c3ad413cce6abd28e43166e75de4da7d5c56abda153e66ed76cb0b36R44-R58) [[7]](diffhunk://#diff-d088af4a1b7b9f5fc32c61ee1e266c60ee110bf97aa0d95540b4951e2fd755e2L16-R18) [[8]](diffhunk://#diff-d088af4a1b7b9f5fc32c61ee1e266c60ee110bf97aa0d95540b4951e2fd755e2L42-R57) [[9]](diffhunk://#diff-d59740a83f9349c2b30e2a7ac058aa9e3d3e8db37ae6f16b14e25f8278ba18d5L29-R32) [[10]](diffhunk://#diff-d59740a83f9349c2b30e2a7ac058aa9e3d3e8db37ae6f16b14e25f8278ba18d5R83-R99) [[11]](diffhunk://#diff-a5175f5530550a07c3973099bdde50bafb11aa82289f0eb2db637eab73a9b622R39-R44)

**Review Items Management**

* Added a new batch-assign API endpoint and supporting contract/command to assign multiple review items to a single media record in one operation, with per-item results and error handling. [[1]](diffhunk://#diff-8980fd02a39f83f29816830910bb05b7ae2e498e4cd4d25af93dce8721c0d741R35-R43) [[2]](diffhunk://#diff-830b1f71036e8e251d988b0468511409040f65792c6c6c111bbf8faf2c39f2acR157-R192) [[3]](diffhunk://#diff-830b1f71036e8e251d988b0468511409040f65792c6c6c111bbf8faf2c39f2acR7)

**Media Statistics and List DTOs**

* Extended `MediaListItemDto` to include `OwnedSeasonCount` for TV shows, and updated the query logic to populate this field. [[1]](diffhunk://#diff-5636f21636ccb11ff7b7bdc36832f08e041d98c97875d4a0b517ec8591dfbb78L41-R42) [[2]](diffhunk://#diff-1433e0662be50dfed535d0d5cee969d73c61e47f35b7df6fa390ce3bb23bd788L80-R89)
* Extended `MediaStatsDto` to include `IncompleteTvShowCount`, and updated stats computation to count TV shows with incomplete season/episode data. [[1]](diffhunk://#diff-5636f21636ccb11ff7b7bdc36832f08e041d98c97875d4a0b517ec8591dfbb78L50-R52) [[2]](diffhunk://#diff-0ffff60cc73b8b2258719953b2545e55dafe8e7796ac44cf12898477bc13cebcR36-R52)

**Bugfixes and Filtering Logic**

* Corrected the watched/unwatched filtering logic in media list queries to more accurately reflect user viewing status.

These changes collectively enhance the flexibility and expressiveness of the API for both frontend consumers and administrators.