### PR TITLE
fix(authentication): JWT claims for prod

### DIFF
--- a/MediaHandler.API/Extensions/ServiceExtensions.cs
+++ b/MediaHandler.API/Extensions/ServiceExtensions.cs
@@ -33,6 +33,14 @@ public static class ServiceExtensions
                     // Auth0 requires a trailing slash on the authority URL for OIDC discovery
                     options.Authority = okta.Domain.TrimEnd('/') + '/';
                     options.Audience = okta.Audience;
+
+                    // Preserve raw JWT claim names (sub, email, name…) instead of remapping
+                    // them to the long XML-schema ClaimTypes equivalents.
+                    // Without this, ASP.NET maps "sub" → ClaimTypes.NameIdentifier, so
+                    // User.FindFirstValue("sub") returns null and /auth/me cannot look up
+                    // the user by OktaId even though the user exists in the database.
+                    options.MapInboundClaims = false;
+
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidateIssuer = true,
@@ -41,7 +49,9 @@ public static class ServiceExtensions
                         ValidateIssuerSigningKey = true,
                         ClockSkew = TimeSpan.FromSeconds(30),
                         // Auth0 places roles in a namespaced custom claim
-                        RoleClaimType = "https://mediahandler.com/roles"
+                        RoleClaimType = "https://mediahandler.com/roles",
+                        // Keep "sub" as the name claim type to stay consistent with raw JWT names
+                        NameClaimType = "sub"
                     };
                 });
         }


### PR DESCRIPTION
This pull request improves JWT authentication handling in the API by ensuring that claim names from Okta/Okta JWTs are preserved in their original form, preventing issues with claim mapping and user identification. The most important changes are:

**Authentication claim handling improvements:**

* Set `options.MapInboundClaims = false` to prevent ASP.NET from remapping standard JWT claim names (like `sub`, `email`, `name`) to .NET's XML-schema equivalents, ensuring that methods like `User.FindFirstValue("sub")` work as expected.
* Explicitly set `TokenValidationParameters.NameClaimType = "sub"` so that the "sub" claim is consistently used as the user's name identifier, matching the raw JWT structure.

**Role claim configuration:**

* Ensured the custom roles claim (`RoleClaimType`) remains mapped to `"https://mediahandler.com/roles"`.